### PR TITLE
Remove Future<std::array<...>> WhenAll specialization

### DIFF
--- a/include/yaclib/algo/detail/when_all_impl.hpp
+++ b/include/yaclib/algo/detail/when_all_impl.hpp
@@ -29,21 +29,16 @@ class AllCombinatorBase<void> {
   yaclib_std::atomic_bool _done = false;
 };
 
-template <typename V, typename E, std::size_t N = 0,
-          typename FutureValue =
-            std::conditional_t<std::is_void_v<V>, void, std::conditional_t<N != 0, std::array<V, N>, std::vector<V>>>>
+template <typename V, typename E, typename FutureValue = std::conditional_t<std::is_void_v<V>, void, std::vector<V>>>
 class AllCombinator : public InlineCore, public AllCombinatorBase<FutureValue> {
   static_assert(std::is_void_v<V> || std::is_nothrow_move_assignable_v<V>);
 
-  using Base = AllCombinatorBase<FutureValue>;
   using ResultPtr = ResultCorePtr<FutureValue, E>;
 
  public:
   static std::pair<ResultPtr, AllCombinator*> Make(std::size_t count) {
-    if constexpr (N == 0) {
-      if (count == 0) {
-        return {nullptr, nullptr};
-      }
+    if (count == 0) {
+      return {nullptr, nullptr};
     }
     // TODO(MBkkt) Maybe single allocation instead of two?
     auto raw_core = new UniqueCounter<ResultCore<FutureValue, E>>{};
@@ -68,7 +63,7 @@ class AllCombinator : public InlineCore, public AllCombinatorBase<FutureValue> {
 
  protected:
   explicit AllCombinator(ResultPtr promise, [[maybe_unused]] std::size_t count) : _promise{std::move(promise)} {
-    if constexpr (!std::is_void_v<V> && N == 0) {
+    if constexpr (!std::is_void_v<V>) {
       AllCombinatorBase<FutureValue>::_results.resize(count);
     }
   }

--- a/include/yaclib/algo/when_all.hpp
+++ b/include/yaclib/algo/when_all.hpp
@@ -61,7 +61,7 @@ auto WhenAll(FutureBase<V, E>&&... futures) {
   static_assert(P == WhenPolicy::FirstFail, "TODO(Ri7ay, MBkkt) Add other policy for WhenAll");
   constexpr std::size_t kSize = sizeof...(V);
   static_assert(kSize >= 2, "WhenAll wants at least two futures");
-  auto [future_core, combinator] = detail::AllCombinator<head_t<V...>, E, kSize>::Make(kSize);
+  auto [future_core, combinator] = detail::AllCombinator<head_t<V...>, E>::Make(kSize);
   detail::WhenImpl(combinator, std::move(futures)...);
   return Future{std::move(future_core)};
 }

--- a/test/unit/algo/when_all.cpp
+++ b/test/unit/algo/when_all.cpp
@@ -84,13 +84,7 @@ void JustWorks() {
 
   EXPECT_TRUE(all.Ready());
 
-  auto expected = [] {
-    if constexpr (suite == TestSuite::Vector) {
-      return std::vector{7, 3, 5};
-    } else {
-      return std::array<int, 3>{7, 3, 5};
-    }
-  }();
+  std::vector expected{7, 3, 5};
   if constexpr (is_void) {
     EXPECT_EQ(std::move(all).Get().State(), yaclib::ResultState::Value);
   } else {


### PR DESCRIPTION
### Purpose

Remove Future<std::array<...>> WhenAll specialization, because it worse, we don't have cheap move without vector

### Related Information

- [ ] Design document: ...
- [ ] Bench PR: ...

### Testing

- [ ] This change is a trivial rework or code cleanup without any test coverage.
- [ ] This change is already covered by existing tests.
- [ ] This PR adds tests that were used to verify all changes.
- [ ] There are tests in an external testing repository: ...
