### PR TITLE
Add lazy pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ https://discord.gg/xy2fDKj8VZ)
 * [Examples](#examples)
     * [Asynchronous pipeline](#asynchronous-pipeline)
     * [C++20 coroutine](#c20-coroutine)
+    * [Lazy pipeline](#lazy-pipeline)
     * [Thread pool](#thread-pool)
     * [Strand, Serial executor](#strand-serial-executor)
     * [AsyncMutex](#asyncmutex)
@@ -134,7 +135,7 @@ yaclib::Future<int> task43() {
 }
 ```
 
-You also can zero cost combine Future coroutine code with Future callbacks code.
+You can zero cost combine Future coroutine code with Future callbacks code.
 That allow to use yaclib for smooth transfer from C++17 to C++20 with coroutines.
 
 Also Future with coroutine doesn't make additional allocation for Future,
@@ -144,6 +145,22 @@ and [can be optimize](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p
 And finally co_await doesn't require allocation,
 so you can combine some async operation without allocation.
 
+#### Lazy pipeline
+
+```C++
+auto task = yaclib::Schedule(tp1, [] {
+  return 1; 
+}).Then([] (int x) {
+  return x * 2;
+});
+
+task.Run(); // Run task on tp1
+```
+Same as asynchronous pipeline, but not starting only after Run/ToFuture/Get.
+Task can be used as coroutine return type too.
+
+Also running Task with return Future doesn't make allocation.
+And it doesn't need synchronization, so it even faster than asynchronous pipeline.
 
 #### Thread pool
 
@@ -219,7 +236,8 @@ yaclib::Future<> bar(yaclib::IExecutor& cpu, yaclib::IExecutor& io) {
 }
 ```
 
-This is really zero-cost, just suspend the coroutine and submit its resume to another executor, without synchronization inside the coroutine and allocations anywhere.
+This is really zero-cost, just suspend the coroutine and submit its resume to another executor,
+without synchronization inside the coroutine and allocations anywhere.
 
 #### WhenAll
 
@@ -465,9 +483,11 @@ Our test coverage is 100%, to simplify, we run tests on the cartesian product of
 
 `os x compiler x stdlib x sanitizer x fault injection backend`
 
-However, we realize this philosophy doesn't work for every project, so we also provide [Releases](https://github.com/YACLib/YACLib/releases).
+However, we realize this philosophy doesn't work for every project,
+so we also provide [Releases](https://github.com/YACLib/YACLib/releases).
 
-We don't believe in [SemVer](https://semver.org), check [this](https://gist.github.com/jashkenas/cbd2b088e20279ae2c8e), so we use `year.month.day[.patch]` approach.
+We don't believe in [SemVer](https://semver.org), check [this](https://gist.github.com/jashkenas/cbd2b088e20279ae2c8e),
+so we use `year.month.day[.patch]` approach.
 I'll release a new version if you ask, or I'll decide we have important or enough changes.
 
 ## Contributing
@@ -483,9 +503,13 @@ We are always open for issues and pull requests. For more details you can check 
 
 ## Thanks
 
-* [Roman Lipovsky](https://gitlab.com/Lipovsky) for an incredible [course about concurrency](https://gitlab.com/Lipovsky/concurrency-course), which gave us a lot of ideas for this library and for showing us how important to test concurrency correctly.
+* [Roman Lipovsky](https://gitlab.com/Lipovsky) for an incredible
+  [course about concurrency](https://gitlab.com/Lipovsky/concurrency-course),
+  which gave us a lot of ideas for this library and for showing us how important to test concurrency correctly.
 
-* Paul E. McKenney for an incredible [book about parallel programming](https://cdn.kernel.org/pub/linux/kernel/people/paulmck/perfbook/perfbook.html), which gave me a lot of insight into memory models and how they relate to what's going on in hardware.
+* Paul E. McKenney for an incredible
+  [book about parallel programming](https://cdn.kernel.org/pub/linux/kernel/people/paulmck/perfbook/perfbook.html),
+  which gave me a lot of insight into memory models and how they relate to what's going on in hardware.
 
 ## Contacts
 

--- a/include/yaclib/async/detail/base_core.hpp
+++ b/include/yaclib/async/detail/base_core.hpp
@@ -29,10 +29,9 @@ class BaseCore : public InlineCore {
   [[nodiscard]] bool SetWait(IRef& callback, State state) noexcept;
   [[nodiscard]] bool ResetWait() noexcept;
 
-  [[nodiscard]] IExecutorPtr& GetExecutor() noexcept;
-  void SetExecutor(IExecutorPtr executor) noexcept;
-
   void SetResult() noexcept;
+
+  void StoreCallback(void* callback, State state) noexcept;
 
  protected:
   explicit BaseCore(State callback) noexcept;
@@ -42,7 +41,9 @@ class BaseCore : public InlineCore {
 #endif
 
   yaclib_std::atomic_uint64_t _callback;
-  IRef* _caller{nullptr};
+
+ public:
+  IRef* _caller;
   IExecutorPtr _executor;
 
  private:

--- a/include/yaclib/async/future.hpp
+++ b/include/yaclib/async/future.hpp
@@ -216,6 +216,7 @@ class [[nodiscard]] FutureOn final : public FutureBase<V, E> {
  public:
   using Base::Base;
   using Base::Detach;
+  using Base::On;
   using Base::Then;
 
   FutureOn(detail::ResultCorePtr<V, E> core) noexcept : Base{std::move(core)} {

--- a/include/yaclib/async/run.hpp
+++ b/include/yaclib/async/run.hpp
@@ -20,7 +20,7 @@ auto Run(IExecutor& e, Func&& f) {
   YACLIB_WARN(e.Tag() == IExecutor::Type::Inline,
               "better way is call func explicit, and use MakeFuture to create Future with func result");
   auto* core = detail::MakeCore<detail::CoreType::Run, void, E>(std::forward<Func>(f));
-  core->SetExecutor(&e);
+  core->_executor = &e;
   using ResultCoreT = typename std::remove_reference_t<decltype(*core)>::Base;
   e.Submit(*core);
   return FutureOn{IntrusivePtr<ResultCoreT>{NoRefTag{}, core}};

--- a/include/yaclib/async/task.hpp
+++ b/include/yaclib/async/task.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <yaclib/async/detail/result_core.hpp>
-#include <yaclib/exe/executor.hpp>
+#include <yaclib/async/future.hpp>
+#include <yaclib/executor/executor.hpp>
+#include <yaclib/executor/inline.hpp>
 #include <yaclib/util/helper.hpp>
 #include <yaclib/util/type_traits.hpp>
 
@@ -9,6 +11,7 @@ namespace yaclib {
 
 /**
  * Provides a mechanism to schedule the some async operations
+ * TODO(MBkkt) add description
  */
 template <typename V = void, typename E = StopError>
 class [[nodiscard]] Task final {
@@ -23,53 +26,44 @@ class [[nodiscard]] Task final {
   Task(Task&& other) noexcept = default;
   Task& operator=(Task&& other) noexcept = default;
 
-  /**
-   * The default constructor creates not a \ref Valid Task
-   *
-   * Needed only for usability, e.g. instead of std::optional<Task<T>> in containers.
-   */
   Task() noexcept = default;
-
-  /**
-   * If Task is \ref Valid then call \ref Stop
-   */
   ~Task() noexcept;
 
-  /**
-   * Attach the continuation func to *this
-   *
-   * The func will be executed on the specified executor.
-   * \note The behavior is undefined if \ref Valid is false before the call to this function.
-   * \param e Executor which will \ref Execute the continuation
-   * \param f A continuation to be attached
-   * \return New \ref TaskOn object associated with the func result
-   */
-  template <typename Func>
-  /*Task*/ auto Then(IExecutor& e, Func&& f) && {
-  }
+  [[nodiscard]] bool Valid() const& noexcept;
 
   /**
-   * Attach the continuation func to *this
-   *
-   * The func will be executed on \ref Inline executor.
-   * \note The behavior is undefined if \ref Valid is false before the call to this function.
-   * \param f A continuation to be attached
-   * \return New \ref TaskOn object associated with the func result
+   * TODO(MBkkt) think about force On/Detach/ToFuture:
+   *  It's able to set passed executor to previous nullptr/all/head/etc or replace
    */
+  Task<V, E> On(IExecutor& e) && noexcept;
+  Task<V, E> On(std::nullptr_t) && noexcept;
+
   template <typename Func>
-  /*Task*/ auto ThenInline(Func&& f) && {
+  /*Task*/ auto Then(IExecutor& e, Func&& f) &&;
+  template <typename Func>
+  /*Task*/ auto ThenInline(Func&& f) &&;
+  template <typename Func>
+  /*Task*/ auto Then(Func&& f) &&;
+
+  void Cancel() &&;
+
+  void Detach(IExecutor& e = MakeInline()) && noexcept;
+
+  Future<V, E> ToFuture() && noexcept;
+  FutureOn<V, E> ToFuture(IExecutor& e) && noexcept;
+
+  Result<V, E> Get(IExecutor& e = MakeInline()) && noexcept {  // Stub implementation
+    // TODO(MBkkt) make it better: we can remove concurrent atomic changes from here
+    return std::move(*this).ToFuture(e).Get();
   }
 
-  FutureOn<V, E> Run() {
-  }
   /**
    * Method that get internal Core state
    *
    * \return internal Core state ptr
    */
   [[nodiscard]] detail::ResultCorePtr<V, E>& GetCore() noexcept;
-
-  explicit Task(detail::ResultCorePtr<V, E> core) noexcept;
+  Task(detail::ResultCorePtr<V, E> core) noexcept;
 
  private:
   detail::ResultCorePtr<V, E> _core;
@@ -77,19 +71,145 @@ class [[nodiscard]] Task final {
 
 extern template class Task<void, StopError>;
 
-/**
- * Execute Callable func on executor
- *
- * \param e executor to be used to execute f and saved as callback executor for return \ref Future
- * \param f func to execute
- * \return \ref Task corresponding f return value
- */
-template <typename E = StopError, typename Func>
-auto Lazy(IExecutor& e, Func&& f) {
+namespace detail {
+
+template <typename E, typename Func>
+auto Schedule(IExecutor* e, Func&& f) {
   auto* core = detail::MakeCore<detail::CoreType::Run, void, E>(std::forward<Func>(f));
-  core->SetExecutor(&e);
+  core->_executor = e;
   using ResultCoreT = typename std::remove_reference_t<decltype(*core)>::Base;
   return Task{IntrusivePtr<ResultCoreT>{NoRefTag{}, core}};
+}
+
+template <bool Force = false>
+void Run(detail::BaseCore* head, IExecutor& e) noexcept;
+
+extern template void Run<false>(detail::BaseCore* head, IExecutor& e) noexcept;
+extern template void Run<true>(detail::BaseCore* head, IExecutor& e) noexcept;
+
+}  // namespace detail
+
+template <typename V, typename E>
+Task<V, E>::~Task() noexcept {
+  if (Valid()) {
+    std::move(*this).Cancel();
+  }
+}
+
+template <typename V, typename E>
+bool Task<V, E>::Valid() const& noexcept {
+  return _core != nullptr;
+}
+
+template <typename V, typename E>
+Task<V, E> Task<V, E>::On(IExecutor& e) && noexcept {
+  _core->_executor = &e;
+  return {std::move(_core)};
+}
+
+template <typename V, typename E>
+Task<V, E> Task<V, E>::On(std::nullptr_t) && noexcept {
+  _core->_executor = nullptr;
+  return {std::move(this->_core)};
+}
+
+template <typename V, typename E>
+template <typename Func>
+auto Task<V, E>::Then(IExecutor& e, Func&& f) && {
+  _core->_executor = &e;
+  return detail::SetCallback<detail::CoreType::Then, detail::CallbackType::Lazy>(_core, std::forward<Func>(f));
+}
+
+template <typename V, typename E>
+template <typename Func>
+auto Task<V, E>::ThenInline(Func&& f) && {
+  return detail::SetCallback<detail::CoreType::Then, detail::CallbackType::LazyInline>(_core, std::forward<Func>(f));
+}
+
+template <typename V, typename E>
+template <typename Func>
+auto Task<V, E>::Then(Func&& f) && {
+  return detail::SetCallback<detail::CoreType::Then, detail::CallbackType::Lazy>(_core, std::forward<Func>(f));
+}
+
+template <typename V, typename E>
+void Task<V, E>::Cancel() && {
+  _core->StoreCallback(static_cast<IRef*>(&MakeInline(StopTag{})), detail::InlineCore::kWaitDrop);
+  detail::Run<true>(_core.Release(), MakeInline(StopTag{}));
+}
+
+template <typename V, typename E>
+void Task<V, E>::Detach(IExecutor& e) && noexcept {
+  _core->StoreCallback(static_cast<IRef*>(&MakeInline()), detail::InlineCore::kWaitDrop);
+  detail::Run(_core.Release(), e);
+}
+
+template <typename V, typename E>
+Future<V, E> Task<V, E>::ToFuture() && noexcept {
+  detail::Run(_core.Get(), MakeInline());
+  _core->_executor = nullptr;
+  return {std::move(_core)};
+}
+
+template <typename V, typename E>
+FutureOn<V, E> Task<V, E>::ToFuture(IExecutor& e) && noexcept {
+  YACLIB_WARN(e.Tag() == IExecutor::Type::Inline, "better way is use ToFuture() instead of ToFuture(MakeInline())");
+  detail::Run(_core.Get(), e);
+  _core->_executor = &e;
+  return {std::move(_core)};
+}
+
+template <typename V, typename E>
+detail::ResultCorePtr<V, E>& Task<V, E>::GetCore() noexcept {
+  return _core;
+}
+
+template <typename V, typename E>
+Task<V, E>::Task(detail::ResultCorePtr<V, E> core) noexcept : _core{std::move(core)} {
+}
+
+/**
+ * TODO(MBkkt) add description
+ */
+template <typename E = StopError, typename Func>
+/*Task*/ auto Schedule(IExecutor& e, Func&& f) {
+  auto task = detail::Schedule<E>(&e, std::forward<Func>(f));
+  e.IncRef();
+  task.GetCore()->_caller = &e;
+  return task;
+}
+
+/**
+ * TODO(MBkkt) add description
+ */
+template <typename E = StopError, typename Func>
+/*Task*/ auto Schedule(Func&& f) {
+  auto task = detail::Schedule<E>(nullptr, std::forward<Func>(f));
+  task.GetCore()->_caller = nullptr;
+  return task;
+}
+
+/**
+ * TODO(MBkkt) add description
+ */
+template <typename V = Unit, typename E = StopError, typename... Args>
+/*Task*/ auto MakeTask(Args&&... args) {
+  // TODO(MBkkt) optimize sizeof: now we store Result twice
+  if constexpr (sizeof...(Args) == 0) {
+    return Schedule<E>(MakeInline(), [] {
+    });
+  } else if constexpr (sizeof...(Args) == 1) {
+    using T = std::conditional_t<std::is_same_v<V, Unit>, head_t<Args...>, V>;
+    static_assert(!std::is_same_v<T, Unit>);
+    return Schedule<E>(MakeInline(), [result = Result<T, E>{std::forward<Args>(args)...}]() mutable {
+      return std::move(result);
+    });
+  } else {
+    static_assert(!std::is_same_v<V, Unit>);
+    return Schedule<E>(MakeInline(), [result = Result<V, E>{std::forward<Args>(args)...}]() mutable {
+      return std::move(result);
+    });
+  }
 }
 
 }  // namespace yaclib

--- a/include/yaclib/coroutine/future_traits.hpp
+++ b/include/yaclib/coroutine/future_traits.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <yaclib/async/future.hpp>
+#include <yaclib/async/task.hpp>
 #include <yaclib/coroutine/detail/promise_type.hpp>
 
 /**
@@ -8,5 +9,13 @@
  */
 template <typename V, typename E, typename... Args>
 struct yaclib_std::coroutine_traits<yaclib::Future<V, E>, Args...> final {
-  using promise_type = yaclib::detail::PromiseType<V, E>;
+  using promise_type = yaclib::detail::PromiseType<V, E, false>;
+};
+
+/**
+ * TODO(mkornaukhov03) Add doxygen docs
+ */
+template <typename V, typename E, typename... Args>
+struct yaclib_std::coroutine_traits<yaclib::Task<V, E>, Args...> final {
+  using promise_type = yaclib::detail::PromiseType<V, E, true>;
 };

--- a/include/yaclib/executor/executor.hpp
+++ b/include/yaclib/executor/executor.hpp
@@ -23,15 +23,15 @@ class IExecutor : public IRef {
   /**
    * Return type of this executor
    */
-  [[nodiscard]] virtual Type Tag() const = 0;
+  [[nodiscard]] virtual Type Tag() const noexcept = 0;
 
   /**
    * Submit given task. This method may either Call or Drop the task
    *
    * This method increments reference counter if task is submitted.
-   * \param task task to execute
+   * \param job job to execute
    */
-  virtual void Submit(Job& task) noexcept = 0;
+  virtual void Submit(Job& job) noexcept = 0;
 };
 
 using IExecutorPtr = IntrusivePtr<IExecutor>;

--- a/include/yaclib/executor/inline.hpp
+++ b/include/yaclib/executor/inline.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <yaclib/executor/executor.hpp>
+#include <yaclib/fwd.hpp>
 
 namespace yaclib {
 
@@ -34,5 +35,7 @@ namespace yaclib {
  * \endcode
  */
 IExecutor& MakeInline() noexcept;
+
+IExecutor& MakeInline(StopTag) noexcept;
 
 }  // namespace yaclib

--- a/include/yaclib/executor/manual.hpp
+++ b/include/yaclib/executor/manual.hpp
@@ -15,7 +15,7 @@ class ManualExecutor : public IExecutor {
   yaclib::detail::List _tasks;
 
  public:
-  [[nodiscard]] Type Tag() const final;
+  [[nodiscard]] Type Tag() const noexcept final;
 
   void Submit(yaclib::Job& f) noexcept final;
 

--- a/include/yaclib/fwd.hpp
+++ b/include/yaclib/fwd.hpp
@@ -20,13 +20,28 @@ class FutureOn;
 template <typename V, typename E>
 class Promise;
 
-/**
- * For internal instead of void usage
- */
-struct Unit final {};
+#define YACLIB_DEFINE_VOID_TYPE(type)                                                                                  \
+  struct type {};                                                                                                      \
+  constexpr bool operator==(type, type) noexcept {                                                                     \
+    return true;                                                                                                       \
+  }                                                                                                                    \
+  constexpr bool operator!=(type, type) noexcept {                                                                     \
+    return false;                                                                                                      \
+  }                                                                                                                    \
+  constexpr bool operator<(type, type) noexcept {                                                                      \
+    return false;                                                                                                      \
+  }                                                                                                                    \
+  constexpr bool operator<=(type, type) noexcept {                                                                     \
+    return true;                                                                                                       \
+  }                                                                                                                    \
+  constexpr bool operator>=(type, type) noexcept {                                                                     \
+    return true;                                                                                                       \
+  }                                                                                                                    \
+  constexpr bool operator>(type, type) noexcept {                                                                      \
+    return false;                                                                                                      \
+  }
 
-constexpr bool operator==(const Unit&, const Unit&) noexcept {
-  return true;
-}
+YACLIB_DEFINE_VOID_TYPE(Unit);
+YACLIB_DEFINE_VOID_TYPE(StopTag);
 
 }  // namespace yaclib

--- a/include/yaclib/util/result.hpp
+++ b/include/yaclib/util/result.hpp
@@ -18,8 +18,6 @@ enum class ResultState : char {
   Empty = 3,
 };
 
-struct StopTag final {};
-
 /**
  * Default error
  */

--- a/include/yaclib/util/type_traits.hpp
+++ b/include/yaclib/util/type_traits.hpp
@@ -30,6 +30,8 @@ template <typename T>
 inline constexpr bool is_future_base_v = detail::IsInstantiationOf<FutureBase, T>::Value ||  //
                                          detail::IsInstantiationOf<Future, T>::Value ||      //
                                          detail::IsInstantiationOf<FutureOn, T>::Value;
+template <typename T>
+inline constexpr bool is_task_v = detail::IsInstantiationOf<Task, T>::Value;
 
 template <typename T>
 using future_base_value_t = typename detail::FutureBaseTypes<T>::Value;
@@ -44,6 +46,7 @@ constexpr bool Check() noexcept {
   static_assert(!std::is_volatile_v<T>, "T cannot be volatile, because it's unnecessary");
   static_assert(!is_result_v<T>, "T cannot be Result, because it's ambiguous");
   static_assert(!is_future_base_v<T>, "T cannot be Future, because it's ambiguous");
+  static_assert(!is_task_v<T>, "T cannot be Task, because it's ambiguous");
   static_assert(!std::is_same_v<T, std::exception_ptr>, "T cannot be std::exception_ptr, because it's ambiguous");
   static_assert(!std::is_same_v<T, Unit>, "T cannot be Unit, because Unit for internal instead of void usage");
   return true;

--- a/src/async/CMakeLists.txt
+++ b/src/async/CMakeLists.txt
@@ -3,6 +3,7 @@ list(APPEND YACLIB_INCLUDES
   ${YACLIB_INCLUDE_DIR}/async/future.hpp
   ${YACLIB_INCLUDE_DIR}/async/promise.hpp
   ${YACLIB_INCLUDE_DIR}/async/run.hpp
+  ${YACLIB_INCLUDE_DIR}/async/task.hpp
   )
 list(APPEND YACLIB_HEADERS
   ${YACLIB_INCLUDE_DIR}/async/detail/base_core.hpp
@@ -17,6 +18,7 @@ list(APPEND YACLIB_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/future_impl.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/promise_impl.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/result_core.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/task_impl.cpp
   )
 
 add_files()

--- a/src/async/base_core.cpp
+++ b/src/async/base_core.cpp
@@ -58,14 +58,6 @@ bool BaseCore::Empty() const noexcept {
   return callback == kEmpty;
 }
 
-IExecutorPtr& BaseCore::GetExecutor() noexcept {
-  return _executor;
-}
-
-void BaseCore::SetExecutor(IExecutorPtr executor) noexcept {
-  _executor = std::move(executor);
-}
-
 BaseCore::BaseCore(State callback) noexcept : _callback{callback}, _caller{&kEmptyRef} {
 }
 
@@ -111,6 +103,11 @@ bool BaseCore::SetCallback(void* callback, State state) noexcept {
   return _callback.load(std::memory_order_acquire) == expected &&
          _callback.compare_exchange_strong(expected, state | reinterpret_cast<std::uint64_t>(callback),
                                            std::memory_order_release, std::memory_order_acquire);
+}
+
+void BaseCore::StoreCallback(void* callback, State state) noexcept {
+  // TODO with atomic_ref can be non atomic store
+  _callback.store(state | reinterpret_cast<std::uint64_t>(callback), std::memory_order_relaxed);
 }
 
 void BaseCore::Submit(BaseCore& callback) noexcept {

--- a/src/async/task_impl.cpp
+++ b/src/async/task_impl.cpp
@@ -1,0 +1,46 @@
+#include <yaclib/async/task.hpp>
+
+namespace yaclib {
+namespace detail {
+namespace {
+
+template <bool Force>
+bool MoveToCaller(BaseCore*& iterator, IExecutor& e) noexcept {
+  if (iterator->next == nullptr) {
+    return false;
+  }
+  auto* caller = static_cast<BaseCore*>(iterator->next);
+  iterator->next = nullptr;
+  if (Force || !caller->_executor) {
+    caller->_executor = &e;
+  }
+  iterator = caller;
+  return true;
+}
+
+}  // namespace
+
+template <bool Force>
+void Run(BaseCore* head, IExecutor& e) noexcept {
+  while (MoveToCaller<Force>(head, e)) {
+  }
+  auto* head_executor = static_cast<IExecutor*>(head->_caller);
+  if (head_executor == nullptr) {
+    e.IncRef();
+    head->_caller = head_executor = &e;
+  }
+  if constexpr (Force) {
+    e.Submit(*head);
+  } else {
+    head_executor->Submit(*head);
+  }
+}
+
+template void Run<false>(detail::BaseCore* head, IExecutor& e) noexcept;
+template void Run<true>(detail::BaseCore* head, IExecutor& e) noexcept;
+
+}  // namespace detail
+
+template class Task<void, StopError>;
+
+}  // namespace yaclib

--- a/src/executor/inline.cpp
+++ b/src/executor/inline.cpp
@@ -6,24 +6,34 @@
 namespace yaclib {
 namespace detail {
 
+template <bool Stop>
 class Inline final : public NopeCounter<IExecutor> {
  private:
-  [[nodiscard]] Type Tag() const final {
+  [[nodiscard]] Type Tag() const noexcept final {
     return Type::Inline;
   }
 
   void Submit(Job& task) noexcept final {
-    task.Call();
+    if constexpr (Stop) {
+      task.Drop();
+    } else {
+      task.Call();
+    }
   }
 };
 
 // TODO(MBkkt) Make file with depended globals
-static Inline sInline;
+static Inline<false> sAliveInline;
+static Inline<true> sStopInline;
 
 }  // namespace detail
 
 IExecutor& MakeInline() noexcept {
-  return detail::sInline;
+  return detail::sAliveInline;
+}
+
+IExecutor& MakeInline(StopTag) noexcept {
+  return detail::sStopInline;
 }
 
 }  // namespace yaclib

--- a/src/executor/manual.cpp
+++ b/src/executor/manual.cpp
@@ -6,8 +6,8 @@
 
 namespace yaclib {
 
-IExecutor::Type ManualExecutor::Tag() const {
-  return yaclib::IExecutor::Type::Custom;
+IExecutor::Type ManualExecutor::Tag() const noexcept {
+  return Type::Custom;
 }
 
 void ManualExecutor::Submit(yaclib::Job& f) noexcept {

--- a/src/executor/strand.cpp
+++ b/src/executor/strand.cpp
@@ -22,7 +22,7 @@ class /*alignas(kCacheLineSize)*/ Strand : public Job, public IExecutor {
   }
 
  private:
-  [[nodiscard]] Type Tag() const final {
+  [[nodiscard]] Type Tag() const noexcept final {
     return Type::Strand;
   }
 

--- a/src/executor/thread_pool.cpp
+++ b/src/executor/thread_pool.cpp
@@ -41,7 +41,7 @@ class ThreadPool : public IThreadPool, private IFunc {
   }
 
  private:
-  Type Tag() const final {
+  Type Tag() const noexcept final {
     return Type::ThreadPool;
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,8 @@ set(YACLIB_UNIT_SOURCES
   unit/util/intrusive_ptr
   unit/util/result
   unit/executor/task
+  unit/async/task
+  unit/async/make_task
   unit/async/make_future
   unit/async/get
   unit/async/future

--- a/test/unit/async/make_future.cpp
+++ b/test/unit/async/make_future.cpp
@@ -24,22 +24,22 @@ struct Kek {
 TEST(MakeReadyFuture, Void) {
   {
     yaclib::Future<> f = yaclib::MakeFuture();
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_EQ(std::move(f).Get().Ok(), yaclib::Unit{});
   }
   {
     yaclib::Future<> f = yaclib::MakeFuture<>();
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_EQ(std::move(f).Get().Ok(), yaclib::Unit{});
   }
   {
     yaclib::Future<> f = yaclib::MakeFuture<void>();
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_EQ(std::move(f).Get().Ok(), yaclib::Unit{});
   }
   {
     yaclib::Future<void, LikeErrorCode> f = yaclib::MakeFuture<void, LikeErrorCode>();
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_EQ(std::move(f).Get().Ok(), yaclib::Unit{});
   }
 }
@@ -47,17 +47,17 @@ TEST(MakeReadyFuture, Void) {
 TEST(MakeReadyFuture, Int) {
   {
     yaclib::Future<int> f = yaclib::MakeFuture(1);
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_EQ(std::move(f).Get().Ok(), 1);
   }
   {
     yaclib::Future<int> f = yaclib::MakeFuture<int>(1);
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_EQ(std::move(f).Get().Ok(), 1);
   }
   {
     yaclib::Future<int, LikeErrorCode> f = yaclib::MakeFuture<int, LikeErrorCode>(1);
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_EQ(std::move(f).Get().Ok(), 1);
   }
 }
@@ -66,12 +66,12 @@ TEST(MakeReadyFuture, Args1) {
   Kek kek{1};
   {
     yaclib::Future<Kek> f = yaclib::MakeFuture<Kek>(1);
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_EQ(std::move(f).Get().Ok(), kek);
   }
   {
     yaclib::Future<Kek, LikeErrorCode> f = yaclib::MakeFuture<Kek, LikeErrorCode>(1);
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_EQ(std::move(f).Get().Ok(), kek);
   }
 }
@@ -80,12 +80,12 @@ TEST(MakeReadyFuture, Args2) {
   Kek kek{2, "rara"};
   {
     yaclib::Future<Kek> f = yaclib::MakeFuture<Kek>(2, "rara");
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_EQ(std::move(f).Get().Ok(), kek);
   }
   {
     yaclib::Future<Kek, LikeErrorCode> f = yaclib::MakeFuture<Kek, LikeErrorCode>(2, "rara");
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_EQ(std::move(f).Get().Ok(), kek);
   }
 }
@@ -93,13 +93,13 @@ TEST(MakeReadyFuture, Args2) {
 TEST(MakeExceptionFuture, Void) {
   {
     yaclib::Future<> f = yaclib::MakeFuture<void>(std::make_exception_ptr(std::runtime_error{""}));
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
   }
   {
     yaclib::Future<void, LikeErrorCode> f =
       yaclib::MakeFuture<void, LikeErrorCode>(std::make_exception_ptr(std::runtime_error{""}));
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
   }
 }
@@ -107,13 +107,13 @@ TEST(MakeExceptionFuture, Void) {
 TEST(MakeExceptionFuture, Int) {
   {
     yaclib::Future<int> f = yaclib::MakeFuture<int>(std::make_exception_ptr(std::runtime_error{""}));
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
   }
   {
     yaclib::Future<int, LikeErrorCode> f =
       yaclib::MakeFuture<int, LikeErrorCode>(std::make_exception_ptr(std::runtime_error{""}));
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
   }
 }
@@ -121,13 +121,13 @@ TEST(MakeExceptionFuture, Int) {
 TEST(MakeExceptionFuture, NonTrivial) {
   {
     yaclib::Future<Kek> f = yaclib::MakeFuture<Kek>(std::make_exception_ptr(std::runtime_error{""}));
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
   }
   {
     yaclib::Future<Kek, LikeErrorCode> f =
       yaclib::MakeFuture<Kek, LikeErrorCode>(std::make_exception_ptr(std::runtime_error{""}));
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
   }
 }
@@ -135,12 +135,12 @@ TEST(MakeExceptionFuture, NonTrivial) {
 TEST(MakeErrorFuture, Void) {
   {
     yaclib::Future<> f = yaclib::MakeFuture<void>(yaclib::StopError{yaclib::StopTag{}});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
   }
   {
     yaclib::Future<void, LikeErrorCode> f = yaclib::MakeFuture<void, LikeErrorCode>(LikeErrorCode{});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
   }
 }
@@ -148,12 +148,12 @@ TEST(MakeErrorFuture, Void) {
 TEST(MakeErrorFuture, Int) {
   {
     yaclib::Future<int> f = yaclib::MakeFuture<int>(yaclib::StopError{yaclib::StopTag{}});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
   }
   {
     yaclib::Future<int, LikeErrorCode> f = yaclib::MakeFuture<int, LikeErrorCode>(LikeErrorCode{});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
   }
 }
@@ -161,12 +161,12 @@ TEST(MakeErrorFuture, Int) {
 TEST(MakeErrorFuture, NonTrivial) {
   {
     yaclib::Future<Kek> f = yaclib::MakeFuture<Kek>(yaclib::StopError{yaclib::StopTag{}});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
   }
   {
     yaclib::Future<Kek, LikeErrorCode> f = yaclib::MakeFuture<Kek, LikeErrorCode>(LikeErrorCode{});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
   }
 }
@@ -174,12 +174,12 @@ TEST(MakeErrorFuture, NonTrivial) {
 TEST(MakeStoppedFuture, Void) {
   {
     yaclib::Future<> f = yaclib::MakeFuture<void>(yaclib::StopTag{});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
   }
   {
     yaclib::Future<void, LikeErrorCode> f = yaclib::MakeFuture<void, LikeErrorCode>(yaclib::StopTag{});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
   }
 }
@@ -187,12 +187,12 @@ TEST(MakeStoppedFuture, Void) {
 TEST(MakeStoppedFuture, Int) {
   {
     yaclib::Future<int> f = yaclib::MakeFuture<int>(yaclib::StopTag{});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
   }
   {
     yaclib::Future<int, LikeErrorCode> f = yaclib::MakeFuture<int, LikeErrorCode>(yaclib::StopTag{});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
   }
 }
@@ -200,12 +200,12 @@ TEST(MakeStoppedFuture, Int) {
 TEST(MakeStoppedFuture, NonTrivial) {
   {
     yaclib::Future<Kek> f = yaclib::MakeFuture<Kek>(yaclib::StopTag{});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
   }
   {
     yaclib::Future<Kek, LikeErrorCode> f = yaclib::MakeFuture<Kek, LikeErrorCode>(yaclib::StopTag{});
-    EXPECT_EQ(f.GetCore()->GetExecutor(), nullptr);
+    EXPECT_EQ(f.GetCore()->_executor, nullptr);
     EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
   }
 }

--- a/test/unit/async/make_task.cpp
+++ b/test/unit/async/make_task.cpp
@@ -1,0 +1,244 @@
+#include <util/error_code.hpp>
+
+#include <yaclib/async/task.hpp>
+
+#include <gtest/gtest.h>
+
+namespace test {
+namespace {
+
+struct Kek {
+  explicit Kek(int x) : _x{x} {
+  }
+  explicit Kek(int x, std::string_view str) : _x{x}, _str{str} {
+  }
+  bool operator==(const Kek& other) const {
+    return _x == other._x && _str == other._str;
+  }
+
+ private:
+  int _x;
+  std::string_view _str;
+};
+
+TEST(MakeReadyTask, Void) {
+  {
+    yaclib::Task<> f = yaclib::MakeTask();
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(std::move(f).Get().Ok(), yaclib::Unit{});
+  }
+  {
+    yaclib::Task<> f = yaclib::MakeTask<>();
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(std::move(f).Get().Ok(), yaclib::Unit{});
+  }
+  {
+    yaclib::Task<> f = yaclib::MakeTask<void>();
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(std::move(f).Get().Ok(), yaclib::Unit{});
+  }
+  {
+    yaclib::Task<void, LikeErrorCode> f = yaclib::MakeTask<void, LikeErrorCode>();
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(std::move(f).Get().Ok(), yaclib::Unit{});
+  }
+}
+
+TEST(MakeReadyTask, Int) {
+  {
+    yaclib::Task<int> f = yaclib::MakeTask(1);
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(std::move(f).Get().Ok(), 1);
+  }
+  {
+    yaclib::Task<int> f = yaclib::MakeTask<int>(1);
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(std::move(f).Get().Ok(), 1);
+  }
+  {
+    yaclib::Task<int, LikeErrorCode> f = yaclib::MakeTask<int, LikeErrorCode>(1);
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(std::move(f).Get().Ok(), 1);
+  }
+}
+
+TEST(MakeReadyTask, Args1) {
+  Kek kek{1};
+  {
+    yaclib::Task<Kek> f = yaclib::MakeTask<Kek>(1);
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(std::move(f).Get().Ok(), kek);
+  }
+  {
+    yaclib::Task<Kek, LikeErrorCode> f = yaclib::MakeTask<Kek, LikeErrorCode>(1);
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(std::move(f).Get().Ok(), kek);
+  }
+}
+
+TEST(MakeReadyTask, Args2) {
+  Kek kek{2, "rara"};
+  {
+    yaclib::Task<Kek> f = yaclib::MakeTask<Kek>(2, "rara");
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(std::move(f).Get().Ok(), kek);
+  }
+  {
+    yaclib::Task<Kek, LikeErrorCode> f = yaclib::MakeTask<Kek, LikeErrorCode>(2, "rara");
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(std::move(f).Get().Ok(), kek);
+  }
+}
+
+TEST(MakeExceptionTask, Void) {
+  {
+    yaclib::Task<> f = yaclib::MakeTask<void>(std::make_exception_ptr(std::runtime_error{""}));
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
+  }
+  {
+    yaclib::Task<void, LikeErrorCode> f =
+      yaclib::MakeTask<void, LikeErrorCode>(std::make_exception_ptr(std::runtime_error{""}));
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
+  }
+}
+
+TEST(MakeExceptionTask, Int) {
+  {
+    yaclib::Task<int> f = yaclib::MakeTask<int>(std::make_exception_ptr(std::runtime_error{""}));
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
+  }
+  {
+    yaclib::Task<int, LikeErrorCode> f =
+      yaclib::MakeTask<int, LikeErrorCode>(std::make_exception_ptr(std::runtime_error{""}));
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
+  }
+}
+
+TEST(MakeExceptionTask, NonTrivial) {
+  {
+    yaclib::Task<Kek> f = yaclib::MakeTask<Kek>(std::make_exception_ptr(std::runtime_error{""}));
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
+  }
+  {
+    yaclib::Task<Kek, LikeErrorCode> f =
+      yaclib::MakeTask<Kek, LikeErrorCode>(std::make_exception_ptr(std::runtime_error{""}));
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), std::runtime_error);
+  }
+}
+
+TEST(MakeErrorTask, Void) {
+  {
+    yaclib::Task<> f = yaclib::MakeTask<void>(yaclib::StopError{yaclib::StopTag{}});
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
+  }
+  {
+    yaclib::Task<void, LikeErrorCode> f = yaclib::MakeTask<void, LikeErrorCode>(LikeErrorCode{});
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
+  }
+}
+
+TEST(MakeErrorTask, Int) {
+  {
+    yaclib::Task<int> f = yaclib::MakeTask<int>(yaclib::StopError{yaclib::StopTag{}});
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
+  }
+  {
+    yaclib::Task<int, LikeErrorCode> f = yaclib::MakeTask<int, LikeErrorCode>(LikeErrorCode{});
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
+  }
+}
+
+TEST(MakeErrorTask, NonTrivial) {
+  {
+    yaclib::Task<Kek> f = yaclib::MakeTask<Kek>(yaclib::StopError{yaclib::StopTag{}});
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
+  }
+  {
+    yaclib::Task<Kek, LikeErrorCode> f = yaclib::MakeTask<Kek, LikeErrorCode>(LikeErrorCode{});
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
+  }
+}
+
+TEST(MakeStoppedTask, Void) {
+  {
+    yaclib::Task<> f = yaclib::MakeTask<void>(yaclib::StopTag{});
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
+  }
+  {
+    yaclib::Task<void, LikeErrorCode> f = yaclib::MakeTask<void, LikeErrorCode>(yaclib::StopTag{});
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
+  }
+}
+
+TEST(MakeStoppedTask, Int) {
+  {
+    yaclib::Task<int> f = yaclib::MakeTask<int>(yaclib::StopTag{});
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
+  }
+  {
+    yaclib::Task<int, LikeErrorCode> f = yaclib::MakeTask<int, LikeErrorCode>(yaclib::StopTag{});
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
+  }
+}
+
+TEST(MakeStoppedTask, NonTrivial) {
+  {
+    yaclib::Task<Kek> f = yaclib::MakeTask<Kek>(yaclib::StopTag{});
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<yaclib::StopError>);
+  }
+  {
+    yaclib::Task<Kek, LikeErrorCode> f = yaclib::MakeTask<Kek, LikeErrorCode>(yaclib::StopTag{});
+    EXPECT_EQ(f.GetCore()->_caller, &yaclib::MakeInline());
+    EXPECT_EQ(f.GetCore()->_executor, &yaclib::MakeInline());
+    EXPECT_THROW(std::move(f).Get().Ok(), yaclib::ResultError<LikeErrorCode>);
+  }
+}
+
+}  // namespace
+}  // namespace test

--- a/test/unit/async/task.cpp
+++ b/test/unit/async/task.cpp
@@ -1,0 +1,103 @@
+#include <yaclib/async/task.hpp>
+#include <yaclib/executor/thread_pool.hpp>
+#include <yaclib/util/result.hpp>
+
+#include <thread>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace test {
+namespace {
+
+TEST(Task, Simple) {
+  size_t called = 0;
+  yaclib::Task<> task = yaclib::Schedule([&] {
+                          called += 1;
+                        })
+                          .On(nullptr)
+                          .Then([&] {
+                            called += 2;
+                          })
+                          .Then([&] {
+                            called += 3;
+                          });
+
+  auto tp = yaclib::MakeThreadPool(1);
+  EXPECT_TRUE(task.Valid());
+  yaclib::FutureOn<> future = std::move(task).ToFuture(*tp);
+  EXPECT_FALSE(task.Valid());
+  std::ignore = std::move(future).Get();
+
+  EXPECT_EQ(called, 6);
+
+  tp->Stop();
+  tp->Wait();
+}
+
+TEST(Task, Simple2) {
+  auto tp = yaclib::MakeThreadPool(1);
+
+  size_t called = 0;
+  yaclib::Task<> task = yaclib::Schedule(*tp,
+                                         [&] {
+                                           called += 1;
+                                         })
+                          .Then([&] {
+                            called += 2;
+                          })
+                          .On(*tp)
+                          .Then([&] {
+                            called += 3;
+                          });
+  EXPECT_TRUE(task.Valid());
+  yaclib::Future<> future = std::move(task).ToFuture();
+  EXPECT_FALSE(task.Valid());
+  std::ignore = std::move(future).Get();
+
+  EXPECT_EQ(called, 6);
+
+  tp->Stop();
+  tp->Wait();
+}
+
+TEST(Task, Cancel) {
+  auto tp = yaclib::MakeThreadPool(1);
+
+  size_t called = 0;
+  std::ignore = yaclib::MakeTask(1);
+  yaclib::Task<> task1 = yaclib::Schedule([&] {
+                           called += 1;
+                         })
+                           .On(nullptr)
+                           .Then([&] {
+                             called += 2;
+                           })
+                           .Then([&] {
+                             called += 3;
+                           });
+  yaclib::Task<> task2 = yaclib::Schedule(*tp,
+                                          [&] {
+                                            called += 1;
+                                          })
+                           .Then([&] {
+                             called += 2;
+                           })
+                           .On(*tp)
+                           .Then([&] {
+                             called += 3;
+                           });
+  EXPECT_TRUE(task1.Valid());
+  std::move(task1).Cancel();
+  EXPECT_FALSE(task1.Valid());
+  EXPECT_TRUE(task2.Valid());
+  std::move(task2).Cancel();
+  EXPECT_FALSE(task2.Valid());
+  EXPECT_EQ(called, 0);
+  tp->Stop();
+  tp->Wait();
+  EXPECT_EQ(called, 0);
+}
+
+}  // namespace
+}  // namespace test

--- a/test/util/async_suite.hpp
+++ b/test/util/async_suite.hpp
@@ -1,0 +1,52 @@
+#include <yaclib/async/future.hpp>
+#include <yaclib/async/task.hpp>
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace test {
+
+template <typename T>
+struct AsyncSuite : testing::Test {
+  static constexpr bool kIsFuture = yaclib::is_future_base_v<T>;
+  using Type = T;
+};
+
+struct TypeNames {
+  template <typename T>
+  static std::string GetName(int i) {
+    switch (i) {
+      case 0:
+        return "Future";
+      case 1:
+        return "Task";
+      default:
+        return "unknown";
+    }
+  }
+};
+
+using Types = testing::Types<yaclib::Future<>, yaclib::Task<>>;
+
+TYPED_TEST_SUITE(AsyncSuite, Types, TypeNames);
+
+#define INVOKE(executor, func)                                                                                         \
+  [&] {                                                                                                                \
+    if constexpr (TestFixture::kIsFuture) {                                                                            \
+      return yaclib::Run(executor, func);                                                                              \
+    } else {                                                                                                           \
+      return yaclib::Schedule(executor, func);                                                                         \
+    }                                                                                                                  \
+  }()
+
+#define DETACH(future, func)                                                                                           \
+  do {                                                                                                                 \
+    if constexpr (TestFixture::kIsFuture) {                                                                            \
+      std::move(future).Detach(func);                                                                                  \
+    } else {                                                                                                           \
+      std::move(future).Then(func).Detach();                                                                           \
+    }                                                                                                                  \
+  } while (false)
+
+}  // namespace test


### PR DESCRIPTION
### Purpose

[Make async mutex api better](https://github.com/YACLib/YACLib/pull/199/commits/34fcf753a76a7e73b52805e545e926874c57a66e)

[Make unit better, add stop tag to forward](https://github.com/YACLib/YACLib/pull/199/commits/d591137f2dd56c078f6134d5da1ffeca49682050)

[Add lazy pipeline. Minor fixes.](https://github.com/YACLib/YACLib/pull/199/commits/78fe713580c1103c1b3a3861d37a85ab89e2f181)

[Add tests for lazy pipeline](https://github.com/YACLib/YACLib/pull/199/commits/66cb63d73ce049d17cceeca983dc19ab50b84eb5)

### Related Information

- [ ] Design document: ...
- [ ] Bench PR: ...

### Testing

- [ ] This change is a trivial rework or code cleanup without any test coverage.
- [ ] This change is already covered by existing tests.
- [ ] This PR adds tests that were used to verify all changes.
- [ ] There are tests in an external testing repository: ...
