### PR TITLE
Added co_await overload for single future (#194)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Configure CMake
         run: |
           if [[ "${{ matrix.os }}" == "12" ]]; then
+            export SYSTEM_VERSION_COMPAT=1
             compiler_names=(clang) # TODO gnu
             llvm=/usr/local/opt/llvm@8
             cxx_compilers=("$llvm/bin/clang++" g++-7)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,8 @@ endif ()
 
 if (YACLIB_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD ${YACLIB_CXX_STANDARD})
-elseif (NOT CORO IN_LIST YACLIB_FLAGS)
-  message("Set default standard to c++17")
+elseif (NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
-else ()
-  message("Set default standard to c++20")
-  set(CMAKE_CXX_STANDARD 20)
 endif ()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/yaclib/coro/await.hpp
+++ b/include/yaclib/coro/await.hpp
@@ -43,4 +43,9 @@ YACLIB_INLINE auto Await(Iterator begin, Iterator end) noexcept
   return Await(begin, static_cast<std::size_t>(end - begin));
 }
 
+template <typename V, typename E>
+YACLIB_INLINE auto operator co_await(FutureBase<V, E>&& future) noexcept {
+  return detail::AwaitSingleAwaiter{std::move(future.GetCore())};
+}
+
 }  // namespace yaclib

--- a/include/yaclib/coro/await.hpp
+++ b/include/yaclib/coro/await.hpp
@@ -48,4 +48,9 @@ YACLIB_INLINE auto operator co_await(FutureBase<V, E>&& future) noexcept {
   return detail::AwaitSingleAwaiter{std::move(future.GetCore())};
 }
 
+template <typename V, typename E>
+YACLIB_INLINE auto operator co_await(Task<V, E>&& task) noexcept {
+  return detail::TransferSingleAwaiter{std::move(task.GetCore())};
+}
+
 }  // namespace yaclib

--- a/test/unit/coro/await.cpp
+++ b/test/unit/coro/await.cpp
@@ -67,6 +67,22 @@ TYPED_TEST(AsyncSuite, JustWorksRange) {
   tp.Wait();
 }
 
+TYPED_TEST(AsyncSuite, JustWorksCoAwait) {
+  yaclib::FairThreadPool tp;
+  auto coro = [&]() -> std::conditional_t<TestFixture::kIsFuture, yaclib::Future<int>, yaclib::Task<int>> {
+    auto f1 = yaclib::Run(tp, [] {
+      yaclib_std::this_thread::sleep_for(50ms * YACLIB_CI_SLOWDOWN);
+      return 1;
+    });
+
+    co_return co_await std::move(f1);
+  };
+  auto future = coro();
+  EXPECT_EQ(std::move(future).Get().Ok(), 1);
+  tp.HardStop();
+  tp.Wait();
+}
+
 TYPED_TEST(AsyncSuite, CheckSuspend) {
   int counter = 0;
   yaclib::FairThreadPool tp{2};
@@ -118,6 +134,27 @@ TYPED_TEST(AsyncSuite, AwaitNoSuspend) {
     auto future = yaclib::MakeFuture();
 
     co_await Await(future);
+    counter = 2;
+    co_return{};
+  };
+
+  auto outer_future = coro();
+  if constexpr (TestFixture::kIsFuture) {
+    EXPECT_EQ(2, counter);
+  } else {
+    EXPECT_EQ(0, counter);
+  }
+  std::ignore = std::move(outer_future).Get();
+}
+
+TYPED_TEST(AsyncSuite, AwaitSingleNoSuspend) {
+  int counter = 0;
+
+  auto coro = [&]() -> typename TestFixture::Type {
+    counter = 1;
+    auto future = yaclib::MakeFuture();
+
+    co_await std::move(future);
     counter = 2;
     co_return{};
   };


### PR DESCRIPTION
### Purpose

https://github.com/YACLib/YACLib/issues/194

### Related Information

- [ ] Design document: ...
- [ ] Bench PR: ...

### Testing

- [ ] This change is a trivial rework or code cleanup without any test coverage.
- [ ] This change is already covered by existing tests.
- [x] This PR adds tests that were used to verify all changes.
- [ ] There are tests in an external testing repository: ...
