### PR TITLE
Few improvements for WaitGroup and OneShotEvent:

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ https://coveralls.io/github/YACLib/YACLib?branch=main)
 [![Test coverage: codecov](
 https://codecov.io/gh/YACLib/YACLib/branch/main/graph/badge.svg)](
 https://codecov.io/gh/YACLib/YACLib)
+
+<!-- 
+Codacy doesn't work for some reason
 [![Codacy Badge](
 https://app.codacy.com/project/badge/Grade/4113686840a645a8950abdf1197611bd)](
 https://www.codacy.com/gh/YACLib/YACLib/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=YACLib/YACLib&amp;utm_campaign=Badge_Grade)
+-->
 
 [![Discord](
 https://discordapp.com/api/guilds/898966884471423026/widget.png)](

--- a/include/yaclib/algo/wait_group.hpp
+++ b/include/yaclib/algo/wait_group.hpp
@@ -17,7 +17,7 @@ namespace yaclib {
 template <typename Event = OneShotEvent>
 class WaitGroup final {
  public:
-  explicit WaitGroup(std::size_t count = 0) : _event{count} {
+  explicit WaitGroup(std::size_t count = 0) noexcept : _event{count} {
   }
 
   /**
@@ -147,27 +147,33 @@ class WaitGroup final {
 
 #if YACLIB_CORO != 0
   /**
-   * TODO
-   */
-  YACLIB_INLINE auto operator co_await() noexcept {
-    return Await();
-  }
-
-  /**
-   * TODO
+   * See OneShotEvent::Await
    */
   YACLIB_INLINE auto Await() noexcept {
     return _event.Await();
   }
 
   /**
-   * TODO
-   *
-   * \param e TODO
-   * \return TODO
+   * See OneShotEvent::Await
+   */
+  YACLIB_INLINE auto AwaitSticky() noexcept {
+    return _event.AwaitSticky();
+  }
+
+  /**
+   * See OneShotEvent::AwaitOn
    */
   YACLIB_INLINE auto AwaitOn(IExecutor& e) noexcept {
     return _event.AwaitOn(e);
+  }
+
+  /**
+   * just shortcut for co_await wait_group.Await();
+   *
+   * TODO(MBkkt) move all shortcut to AwaitSticky
+   */
+  YACLIB_INLINE auto operator co_await() noexcept {
+    return Await();
   }
 #endif
 

--- a/src/algo/one_shot_event.cpp
+++ b/src/algo/one_shot_event.cpp
@@ -3,7 +3,7 @@
 namespace yaclib {
 namespace {
 
-void SetImpl(yaclib_std::atomic_uintptr_t& self, uint64_t value) {
+void SetImpl(yaclib_std::atomic_uintptr_t& self, std::uintptr_t value) {
   auto head = self.exchange(value, std::memory_order_acq_rel);
   auto* job = reinterpret_cast<Job*>(head);
   while (job != nullptr) {
@@ -16,8 +16,8 @@ void SetImpl(yaclib_std::atomic_uintptr_t& self, uint64_t value) {
 }  // namespace
 
 bool OneShotEvent::TryAdd(Job& job) noexcept {
-  std::uint64_t head = _head.load(std::memory_order_acquire);
-  std::uint64_t node = reinterpret_cast<std::uint64_t>(&job);
+  auto head = _head.load(std::memory_order_acquire);
+  auto node = reinterpret_cast<std::uintptr_t>(&job);
   while (head != OneShotEvent::kAllDone) {
     job.next = reinterpret_cast<Job*>(head);
     if (_head.compare_exchange_weak(head, node, std::memory_order_release, std::memory_order_acquire)) {

--- a/src/algo/one_shot_event.cpp
+++ b/src/algo/one_shot_event.cpp
@@ -1,16 +1,26 @@
 #include <yaclib/algo/one_shot_event.hpp>
 
 namespace yaclib {
+namespace {
 
-OneShotEvent::OneShotEvent() noexcept : _head{OneShotEvent::kEmpty} {
+void SetImpl(yaclib_std::atomic_uintptr_t& self, uint64_t value) {
+  auto head = self.exchange(value, std::memory_order_acq_rel);
+  auto* job = reinterpret_cast<Job*>(head);
+  while (job != nullptr) {
+    auto* next = static_cast<Job*>(job->next);
+    job->Call();
+    job = next;
+  }
 }
 
-bool OneShotEvent::TryAdd(Job* job) noexcept {
-  std::uint64_t head = _head.load(/*std::memory_order_acquire*/);
-  std::uint64_t node = reinterpret_cast<std::uint64_t>(job);
+}  // namespace
+
+bool OneShotEvent::TryAdd(Job& job) noexcept {
+  std::uint64_t head = _head.load(std::memory_order_acquire);
+  std::uint64_t node = reinterpret_cast<std::uint64_t>(&job);
   while (head != OneShotEvent::kAllDone) {
-    job->next = reinterpret_cast<Job*>(head);
-    if (_head.compare_exchange_weak(head, node /*, std::memory_order_release, std::memory_order_acquire*/)) {
+    job.next = reinterpret_cast<Job*>(head);
+    if (_head.compare_exchange_weak(head, node, std::memory_order_release, std::memory_order_acquire)) {
       return true;
     }
   }
@@ -18,36 +28,28 @@ bool OneShotEvent::TryAdd(Job* job) noexcept {
 }
 
 bool OneShotEvent::Ready() noexcept {
-  return _head.load(/*std::memory_order_acquire*/) == OneShotEvent::kAllDone;
+  return _head.load(std::memory_order_acquire) == OneShotEvent::kAllDone;
 }
 
-class OneShotEventWaiter final : public Job, public detail::DefaultEvent {
- public:
-  void Call() noexcept final {
-    Set();
-  }
-};
-
 void OneShotEvent::Wait() noexcept {
-  OneShotEventWaiter waiter;
-  if (TryAdd(static_cast<Job*>(&waiter))) {
+  Waiter waiter;
+  if (TryAdd(waiter)) {
     auto token = waiter.Make();
     waiter.Wait(token);
   }
 }
 
+void OneShotEvent::Call() noexcept {
+  SetImpl(_head, kEmpty);
+}
+
 void OneShotEvent::Set() noexcept {
-  auto head = _head.exchange(OneShotEvent::kAllDone /*, std::memory_order_acq_rel*/);
-  auto job = reinterpret_cast<Job*>(head);
-  while (job != nullptr) {
-    auto next = static_cast<Job*>(job->next);
-    job->Call();
-    job = next;
-  }
+  SetImpl(_head, kAllDone);
 }
 
 void OneShotEvent::Reset() noexcept {
-  _head.store(OneShotEvent::kEmpty /*, std::memory_order_release*/);
+  YACLIB_ASSERT(_head.load(std::memory_order_relaxed) == kAllDone);
+  _head.store(kEmpty, std::memory_order_relaxed);
 }
 
 }  // namespace yaclib

--- a/src/algo/one_shot_event.cpp
+++ b/src/algo/one_shot_event.cpp
@@ -48,7 +48,10 @@ void OneShotEvent::Set() noexcept {
 }
 
 void OneShotEvent::Reset() noexcept {
-  YACLIB_ASSERT(_head.load(std::memory_order_relaxed) == kAllDone);
+#ifdef YACLIB_LOG_DEBUG
+  auto head = _head.load(std::memory_order_relaxed);
+  YACLIB_ASSERT(head == kEmpty || head == kAllDone);
+#endif
   _head.store(kEmpty, std::memory_order_relaxed);
 }
 

--- a/src/coro/CMakeLists.txt
+++ b/src/coro/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND YACLIB_INCLUDES
   ${YACLIB_INCLUDE_DIR}/coro/await.hpp
+  ${YACLIB_INCLUDE_DIR}/coro/await_on.hpp
   ${YACLIB_INCLUDE_DIR}/coro/coro.hpp
   ${YACLIB_INCLUDE_DIR}/coro/current_executor.hpp
   ${YACLIB_INCLUDE_DIR}/coro/future.hpp
@@ -13,6 +14,7 @@ list(APPEND YACLIB_INCLUDES
 
 list(APPEND YACLIB_HEADERS
   ${YACLIB_INCLUDE_DIR}/coro/detail/await_awaiter.hpp
+  ${YACLIB_INCLUDE_DIR}/coro/detail/await_on_awaiter.hpp
   ${YACLIB_INCLUDE_DIR}/coro/detail/on_awaiter.hpp
   ${YACLIB_INCLUDE_DIR}/coro/detail/promise_type.hpp
   )


### PR DESCRIPTION
### Purpose

1. Relax memory orders for OneShotEvent
2. OneShotEvent::Await was incorrect named, in reality it was AwaitSticky
3. Implement real OneShotEvent::Await
4. Add OneShotEvent::Call, same as Set, but doesn't prevent adding new jobs. It's useful for scenarios like:
one thread do some jobs some time, for an example Writer::Commit. other thread, for an example in Transaction::Commit, want to wait and when first Writer::Commit is called.

### Related Information

- [ ] Design document: ...
- [ ] Bench PR: ...

### Testing

- [ ] This change is a trivial rework or code cleanup without any test coverage.
- [ ] This change is already covered by existing tests.
- [ ] This PR adds tests that were used to verify all changes.
- [ ] There are tests in an external testing repository: ...
