### PR TITLE
Fix MSVC/ClangCl sanitizer

### DIFF
--- a/include/yaclib/fault/detail/condition_variable.hpp
+++ b/include/yaclib/fault/detail/condition_variable.hpp
@@ -20,7 +20,9 @@ template <typename Impl>
 class ConditionVariable : private Impl {
  public:
   using Impl::Impl;
+#ifndef _MSC_VER
   using Impl::native_handle;
+#endif
 
   void notify_one() noexcept {
     YACLIB_INJECT_FAULT(Impl::notify_one());

--- a/include/yaclib/fault/detail/mutex.hpp
+++ b/include/yaclib/fault/detail/mutex.hpp
@@ -8,7 +8,9 @@ template <typename Impl>
 class Mutex : protected Impl {
  public:
   using Impl::Impl;
+#ifndef _MSC_VER
   using Impl::native_handle;
+#endif
 
   void lock() {
     YACLIB_INJECT_FAULT(Impl::lock());

--- a/src/config.hpp.in
+++ b/src/config.hpp.in
@@ -148,7 +148,7 @@
 #endif
 // clang-format on
 
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 192829913
+#if YACLIB_HAS_ATTRIBUTE(msvc::no_unique_address)
 #  define YACLIB_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #elif YACLIB_HAS_ATTRIBUTE(no_unique_address)
 // works starts from gcc 9 and clang 9


### PR DESCRIPTION
* Fix detection of `msvc::no_unique_address` for clangcl
* Fix for msvc stl, native_handle was removed