### PR TITLE
Add SharedFuture

### DIFF
--- a/include/yaclib/algo/detail/shared_core.hpp
+++ b/include/yaclib/algo/detail/shared_core.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "yaclib/fwd.hpp"
-
 #include <yaclib/algo/detail/result_core.hpp>
 #include <yaclib/async/future.hpp>
 #include <yaclib/async/promise.hpp>
 #include <yaclib/exe/executor.hpp>
+#include <yaclib/fwd.hpp>
 #include <yaclib/util/ref.hpp>
 
 #include <atomic>
@@ -54,7 +53,7 @@ class SharedCore : public IRef {
   }
 
  private:
-  static constexpr std::uintptr_t kSet = std::numeric_limits<std::uintptr_t>::max();
+  static constexpr auto kSet = std::numeric_limits<std::uintptr_t>::max();
 
   yaclib_std::atomic<ResultCoreType*> _head = nullptr;
   union {

--- a/include/yaclib/algo/detail/shared_core.hpp
+++ b/include/yaclib/algo/detail/shared_core.hpp
@@ -15,10 +15,9 @@ namespace detail {
 template <typename V, typename E>
 class SharedCore : public IRef {
   using ResultCoreType = ResultCore<V, E>;
-  using ResultCorePtrType = detail::ResultCorePtr<V, E>;
 
  public:
-  SharedCore() noexcept {};
+  SharedCore() noexcept {}
 
   void Attach(Promise<V, E>&& p) {
     ResultCoreType* core = p.GetCore().Get();

--- a/include/yaclib/algo/detail/shared_core.hpp
+++ b/include/yaclib/algo/detail/shared_core.hpp
@@ -19,7 +19,7 @@ class SharedCore : public IRef {
   using ResultCorePtrType = detail::ResultCorePtr<V, E>;
 
  public:
-  SharedCore() noexcept : _stub{} {};
+  SharedCore() noexcept {};
 
   void Attach(Promise<V, E>&& p) {
     ResultCoreType* core = p.GetCore().Get();
@@ -58,7 +58,6 @@ class SharedCore : public IRef {
 
   yaclib_std::atomic<ResultCoreType*> _head = nullptr;
   union {
-    Unit _stub;
     Result<V, E> _result;
   };
 };

--- a/include/yaclib/async/detail/shared_core.hpp
+++ b/include/yaclib/async/detail/shared_core.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <yaclib/algo/detail/result_core.hpp>
+#include <yaclib/async/future.hpp>
+#include <yaclib/async/promise.hpp>
+#include <yaclib/exe/executor.hpp>
+#include <yaclib/util/ref.hpp>
+
+#include <atomic>
+
+namespace yaclib {
+namespace detail {
+
+template <typename V, typename E>
+class SharedCore : public IRef {
+  using ResultCoreType = ResultCore<V, E>;
+  using ResultCorePtrType = detail::ResultCorePtr<V, E>;
+
+ public:
+  SharedCore() : _head(nullptr) {
+  }
+
+  Result<V, E> Get() {
+    return GetFuture().Get();
+  }
+
+  Future<V, E> GetFuture() {
+    auto [f, p] = MakeContract<V, E>();
+    Attach(std::move(p));
+    return std::move(f);
+  }
+
+  FutureOn<V, E> GetFutureOn(IExecutor& e) {
+    auto [f, p] = MakeContractOn<V, E>(e);
+    Attach(std::move(p));
+    return std::move(f);
+  };
+
+  void Attach(Promise<V, E>&& p) {
+    ResultCoreType* core = p.GetCore().Get();
+    ResultCoreType* next = _head.load(std::memory_order_acquire);
+    do {
+      if (reinterpret_cast<std::uintptr_t>(next) == kSet) {
+        std::move(p).Set(_result);
+        break;
+      }
+      core->next = next;
+    } while (!_head.compare_exchange_weak(next, core, std::memory_order_release, std::memory_order_acquire));
+    p.GetCore().Release();
+  }
+
+  template <typename... Args>
+  void Set(Args&&... args) {
+    new (&_result) Result<V, E>{std::forward<Args>(args)...};
+
+    auto head = _head.exchange(reinterpret_cast<ResultCoreType*>(kSet), std::memory_order_acq_rel);
+    YACLIB_ASSERT(reinterpret_cast<std::uintptr_t>(head) != kSet);
+
+    while (head) {
+      auto next = head->next;
+      Promise<V, E>{detail::ResultCorePtr<V, E>{NoRefTag{}, head}}.Set(_result);
+      head = static_cast<ResultCoreType*>(next);
+    }
+  }
+
+  ~SharedCore() {
+    YACLIB_ASSERT(reinterpret_cast<std::uintptr_t>(_head.load(std::memory_order_acquire)) == kSet);
+    _result.~Result<V, E>();
+  }
+
+ private:
+  static constexpr std::uintptr_t kSet = std::numeric_limits<std::uintptr_t>::max();
+
+  yaclib_std::atomic<ResultCoreType*> _head;
+  union {
+    Result<V, E> _result;
+  };
+};
+
+template <typename V, typename E>
+using SharedCorePtr = IntrusivePtr<SharedCore<V, E>>;
+
+}  // namespace detail
+}  // namespace yaclib

--- a/include/yaclib/async/shared_contract.hpp
+++ b/include/yaclib/async/shared_contract.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <yaclib/async/shared_future.hpp>
+#include <yaclib/async/shared_promise.hpp>
+
+namespace yaclib {
+
+template <typename V, typename E>
+using SharedContract = std::pair<SharedFuture<V, E>, SharedPromise<V, E>>;
+
+template <typename V = void, typename E = StopError>
+[[nodiscard]] SharedContract<V, E> MakeSharedContract() {
+  auto core = MakeShared<detail::SharedCore<V, E>>(1);
+  SharedFuture<V, E> future{core};
+  SharedPromise<V, E> promise{core};
+  return {std::move(future), std::move(promise)};
+}
+
+}  // namespace yaclib

--- a/include/yaclib/async/shared_future.hpp
+++ b/include/yaclib/async/shared_future.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <yaclib/async/detail/shared_core.hpp>
+
+namespace yaclib {
+
+template <typename V, typename E>
+class SharedFuture final {
+ public:
+  static_assert(Check<V>(), "V should be valid");
+  static_assert(Check<E>(), "E should be valid");
+  static_assert(!std::is_same_v<V, E>, "Future cannot be instantiated with same V and E, because it's ambiguous");
+  static_assert(std::is_copy_constructible_v<Result<V, E>>, "Result should be copyable");
+
+  SharedFuture() : _core(nullptr) {
+  }
+
+  explicit SharedFuture(detail::SharedCorePtr<V, E> core) : _core(std::move(core)) {
+  }
+
+  [[nodiscard]] bool Valid() const& noexcept {
+    return _core != nullptr;
+  }
+
+  [[nodiscard]] Result<V, E> Get() const {
+    YACLIB_ASSERT(Valid());
+    return _core->Get();
+  }
+
+  Future<V, E> GetFuture() const {
+    YACLIB_ASSERT(Valid());
+    return _core->GetFuture();
+  }
+
+  FutureOn<V, E> GetFutureOn(IExecutor& e) const {
+    YACLIB_ASSERT(Valid());
+    return _core->GetFutureOn(e);
+  }
+
+  void Attach(Promise<V, E>&& p) const {
+    YACLIB_ASSERT(Valid());
+    _core->Attach(std::move(p));
+  }
+
+ private:
+  detail::SharedCorePtr<V, E> _core;
+};
+
+}  // namespace yaclib

--- a/include/yaclib/async/shared_future.hpp
+++ b/include/yaclib/async/shared_future.hpp
@@ -1,22 +1,18 @@
 #pragma once
 
-#include <yaclib/async/detail/shared_core.hpp>
+#include <yaclib/algo/detail/shared_core.hpp>
 
 namespace yaclib {
 
 template <typename V, typename E>
 class SharedFuture final {
- public:
   static_assert(Check<V>(), "V should be valid");
   static_assert(Check<E>(), "E should be valid");
-  static_assert(!std::is_same_v<V, E>, "Future cannot be instantiated with same V and E, because it's ambiguous");
+  static_assert(!std::is_same_v<V, E>, "SharedFuture cannot be instantiated with same V and E, because it's ambiguous");
   static_assert(std::is_copy_constructible_v<Result<V, E>>, "Result should be copyable");
 
-  SharedFuture() : _core(nullptr) {
-  }
-
-  explicit SharedFuture(detail::SharedCorePtr<V, E> core) : _core(std::move(core)) {
-  }
+ public:
+  SharedFuture() = default;
 
   [[nodiscard]] bool Valid() const& noexcept {
     return _core != nullptr;
@@ -24,22 +20,32 @@ class SharedFuture final {
 
   [[nodiscard]] Result<V, E> Get() const {
     YACLIB_ASSERT(Valid());
-    return _core->Get();
+    return GetFuture().Get();
   }
 
   Future<V, E> GetFuture() const {
     YACLIB_ASSERT(Valid());
-    return _core->GetFuture();
+    auto [f, p] = MakeContract<V, E>();
+    _core->Attach(std::move(p));
+    return std::move(f);
   }
 
   FutureOn<V, E> GetFutureOn(IExecutor& e) const {
     YACLIB_ASSERT(Valid());
-    return _core->GetFutureOn(e);
+    auto [f, p] = MakeContractOn<V, E>(e);
+    _core->Attach(std::move(p));
+    return std::move(f);
   }
 
   void Attach(Promise<V, E>&& p) const {
     YACLIB_ASSERT(Valid());
     _core->Attach(std::move(p));
+  }
+
+  /**
+   * Part of unsafe but internal API
+   */
+  explicit SharedFuture(detail::SharedCorePtr<V, E> core) noexcept : _core(std::move(core)) {
   }
 
  private:

--- a/include/yaclib/async/shared_promise.hpp
+++ b/include/yaclib/async/shared_promise.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <yaclib/async/detail/shared_core.hpp>
+
+namespace yaclib {
+
+template <typename V, typename E>
+class SharedPromise final {
+ public:
+  SharedPromise() noexcept = default;
+
+  explicit SharedPromise(detail::SharedCorePtr<V, E> core) noexcept : _core(std::move(core)) {
+  }
+
+  SharedPromise(const SharedPromise& other) = delete;
+  SharedPromise& operator=(const SharedPromise& other) = delete;
+
+  SharedPromise(SharedPromise&& other) noexcept = default;
+  SharedPromise& operator=(SharedPromise&& other) noexcept = default;
+
+  [[nodiscard]] bool Valid() const& noexcept {
+    return _core != nullptr;
+  }
+
+  template <typename... Args>
+  void Set(Args&&... args) && {
+    YACLIB_ASSERT(Valid());
+    if constexpr (sizeof...(Args) == 0) {
+      _core->Set(std::in_place);
+    } else {
+      _core->Set(std::forward<Args>(args)...);
+    }
+    _core = nullptr;
+  }
+
+  ~SharedPromise() {
+    if (Valid()) {
+      std::move(*this).Set(StopTag{});
+    }
+  }
+
+ private:
+  detail::SharedCorePtr<V, E> _core;
+};
+
+}  // namespace yaclib

--- a/include/yaclib/async/shared_promise.hpp
+++ b/include/yaclib/async/shared_promise.hpp
@@ -1,16 +1,18 @@
 #pragma once
 
-#include <yaclib/async/detail/shared_core.hpp>
+#include <yaclib/algo/detail/shared_core.hpp>
 
 namespace yaclib {
 
 template <typename V, typename E>
 class SharedPromise final {
+  static_assert(Check<V>(), "V should be valid");
+  static_assert(Check<E>(), "E should be valid");
+  static_assert(!std::is_same_v<V, E>, "Future cannot be instantiated with same V and E, because it's ambiguous");
+  static_assert(std::is_copy_constructible_v<Result<V, E>>, "Result should be copyable");
+
  public:
   SharedPromise() noexcept = default;
-
-  explicit SharedPromise(detail::SharedCorePtr<V, E> core) noexcept : _core(std::move(core)) {
-  }
 
   SharedPromise(const SharedPromise& other) = delete;
   SharedPromise& operator=(const SharedPromise& other) = delete;
@@ -37,6 +39,12 @@ class SharedPromise final {
     if (Valid()) {
       std::move(*this).Set(StopTag{});
     }
+  }
+
+  /**
+   * Part of unsafe but internal API
+   */
+  explicit SharedPromise(detail::SharedCorePtr<V, E> core) noexcept : _core(std::move(core)) {
   }
 
  private:

--- a/include/yaclib/fwd.hpp
+++ b/include/yaclib/fwd.hpp
@@ -49,4 +49,10 @@ class [[nodiscard]] FutureOn;
 template <typename V = void, typename E = StopError>
 class [[nodiscard]] Promise;
 
+template <typename V = void, typename E = StopError>
+class [[nodiscard]] SharedFuture;
+
+template <typename V = void, typename E = StopError>
+class [[nodiscard]] SharedPromise;
+
 }  // namespace yaclib

--- a/src/algo/CMakeLists.txt
+++ b/src/algo/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND YACLIB_HEADERS
   ${YACLIB_INCLUDE_DIR}/algo/detail/core.hpp
   ${YACLIB_INCLUDE_DIR}/algo/detail/inline_core.hpp
   ${YACLIB_INCLUDE_DIR}/algo/detail/result_core.hpp
+  ${YACLIB_INCLUDE_DIR}/algo/detail/shared_core.hpp
   ${YACLIB_INCLUDE_DIR}/algo/detail/wait_event.hpp
   )
 list(APPEND YACLIB_SOURCES

--- a/src/async/CMakeLists.txt
+++ b/src/async/CMakeLists.txt
@@ -14,7 +14,6 @@ list(APPEND YACLIB_INCLUDES
   ${YACLIB_INCLUDE_DIR}/async/when_any.hpp
   )
 list(APPEND YACLIB_HEADERS
-  ${YACLIB_INCLUDE_DIR}/async/detail/shared_core.hpp
   ${YACLIB_INCLUDE_DIR}/async/detail/wait_impl.hpp
   ${YACLIB_INCLUDE_DIR}/async/detail/when_all_impl.hpp
   ${YACLIB_INCLUDE_DIR}/async/detail/when_any_impl.hpp

--- a/src/async/CMakeLists.txt
+++ b/src/async/CMakeLists.txt
@@ -4,6 +4,9 @@ list(APPEND YACLIB_INCLUDES
   ${YACLIB_INCLUDE_DIR}/async/make.hpp
   ${YACLIB_INCLUDE_DIR}/async/promise.hpp
   ${YACLIB_INCLUDE_DIR}/async/run.hpp
+  ${YACLIB_INCLUDE_DIR}/async/shared_contract.hpp
+  ${YACLIB_INCLUDE_DIR}/async/shared_future.hpp
+  ${YACLIB_INCLUDE_DIR}/async/shared_promise.hpp
   ${YACLIB_INCLUDE_DIR}/async/wait.hpp
   ${YACLIB_INCLUDE_DIR}/async/wait_for.hpp
   ${YACLIB_INCLUDE_DIR}/async/wait_until.hpp
@@ -11,6 +14,7 @@ list(APPEND YACLIB_INCLUDES
   ${YACLIB_INCLUDE_DIR}/async/when_any.hpp
   )
 list(APPEND YACLIB_HEADERS
+  ${YACLIB_INCLUDE_DIR}/async/detail/shared_core.hpp
   ${YACLIB_INCLUDE_DIR}/async/detail/wait_impl.hpp
   ${YACLIB_INCLUDE_DIR}/async/detail/when_all_impl.hpp
   ${YACLIB_INCLUDE_DIR}/async/detail/when_any_impl.hpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,6 +57,7 @@ set(YACLIB_UNIT_SOURCES
   unit/algo/when_any
   unit/algo/wait_group
   unit/runtime/fair_thread_pool
+  unit/async/shared_core
   unit/async/stress
   unit/exe/strand
   unit/not_implemented

--- a/test/unit/async/shared_core.cpp
+++ b/test/unit/async/shared_core.cpp
@@ -1,0 +1,208 @@
+#include <yaclib/async/contract.hpp>
+#include <yaclib/async/future.hpp>
+#include <yaclib/async/promise.hpp>
+#include <yaclib/async/shared_contract.hpp>
+#include <yaclib/async/shared_future.hpp>
+#include <yaclib/async/shared_promise.hpp>
+#include <yaclib/exe/submit.hpp>
+#include <yaclib/fwd.hpp>
+#include <yaclib/runtime/fair_thread_pool.hpp>
+
+#include <gtest/gtest.h>
+
+namespace test {
+namespace {
+
+constexpr int SET_VALUE = 5;
+
+TEST(SharedCore, Void) {
+  auto [sf, sp] = yaclib::MakeSharedContract<>();
+  std::move(sp).Set();
+  EXPECT_EQ(sf.Get().Value(), yaclib::Unit{});
+}
+
+TEST(SharedCore, SetGet) {
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+  std::move(sp).Set(SET_VALUE);
+  EXPECT_EQ(sf.Get().Value(), SET_VALUE);
+}
+
+TEST(SharedCore, SetGetFuture) {
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+  std::move(sp).Set(SET_VALUE);
+  auto f = sf.GetFuture();
+  EXPECT_EQ(std::move(f).Get().Value(), SET_VALUE);
+}
+
+TEST(SharedCore, GetFutureSet) {
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+  auto f = sf.GetFuture();
+  std::move(sp).Set(SET_VALUE);
+  EXPECT_EQ(std::move(f).Get().Value(), SET_VALUE);
+}
+
+TEST(SharedCore, GetFutureOn) {
+  yaclib::FairThreadPool tp;
+
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+  auto f = sf.GetFutureOn(tp);
+  std::move(f).Detach([](int value) {
+    EXPECT_EQ(value, SET_VALUE);
+  });
+
+  std::move(sp).Set(SET_VALUE);
+
+  tp.SoftStop();
+  tp.Wait();
+}
+
+TEST(SharedCore, PromiseDtor) {
+  yaclib::SharedFuture<int> sf;
+
+  {
+    auto [sf_internal, sp_internal] = yaclib::MakeSharedContract<int>();
+    std::move(sp_internal).Set(SET_VALUE);
+    sf = sf_internal;
+  }
+
+  auto f1 = sf.GetFuture();
+  EXPECT_EQ(std::move(f1).Get().Value(), SET_VALUE);
+
+  {
+    auto [sf_internal, sp_internal] = yaclib::MakeSharedContract<int>();
+    sf = sf_internal;
+  }
+  auto f2 = sf.GetFuture();
+  EXPECT_EQ(std::move(f2).Get().Error(), yaclib::StopTag{});
+}
+
+TEST(SharedCore, PromiseAttach) {
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+  auto [f, p] = yaclib::MakeContract<int>();
+
+  sf.Attach(std::move(p));
+  std::move(sp).Set(SET_VALUE);
+
+  EXPECT_EQ(std::move(f).Get().Value(), SET_VALUE);
+}
+
+TEST(SharedCore, Concurrent) {
+  yaclib::FairThreadPool tp;
+
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+
+  for (size_t i = 0; i < 10; ++i) {
+    yaclib::Submit(tp, [&sf = sf, &tp]() {
+      sf.GetFuture().Detach(tp, [](int value) {
+        EXPECT_EQ(value, SET_VALUE);
+      });
+    });
+  }
+
+  yaclib::Submit(tp, [sp = std::move(sp)]() mutable {
+    std::move(sp).Set(SET_VALUE);
+  });
+
+  tp.SoftStop();
+  tp.Wait();
+}
+
+TEST(SharedCore, FuturesOutliveShared) {
+  yaclib::Future<int> f;
+
+  {
+    auto [sf, sp] = yaclib::MakeSharedContract<int>();
+    f = sf.GetFuture();
+  }
+
+  EXPECT_EQ(std::move(f).Get().Error(), yaclib::StopTag{});
+
+  yaclib::SharedPromise<int> sp;
+  {
+    yaclib::SharedFuture<int> sf;
+    std::tie(sf, sp) = yaclib::MakeSharedContract<int>();
+    f = sf.GetFuture();
+  }
+
+  std::move(sp).Set(SET_VALUE);
+  EXPECT_EQ(std::move(f).Get().Value(), SET_VALUE);
+}
+
+TEST(SharedCore, CopySharedFuture) {
+  auto [sf1, sp] = yaclib::MakeSharedContract<int>();
+
+  auto sf2 = sf1;
+
+  ASSERT_TRUE(sf1.Valid());
+  ASSERT_TRUE(sf2.Valid());
+
+  auto f1 = sf1.GetFuture();
+  auto f2 = sf2.GetFuture();
+
+  std::move(sp).Set(SET_VALUE);
+
+  ASSERT_EQ(std::move(f1).Get().Value(), SET_VALUE);
+  ASSERT_EQ(std::move(f2).Get().Value(), SET_VALUE);
+}
+
+TEST(SharedCore, MoveSharedFuture) {
+  auto [sf1, sp] = yaclib::MakeSharedContract<int>();
+  ASSERT_EQ(sf1.Valid(), true);
+
+  auto sf2 = std::move(sf1);
+  ASSERT_EQ(sf1.Valid(), false);
+  ASSERT_EQ(sf2.Valid(), true);
+
+  std::move(sp).Set(SET_VALUE);
+  ASSERT_EQ(sf2.Get().Value(), SET_VALUE);
+}
+
+TEST(SharedCore, MoveSharedPromise) {
+  auto [sf, sp1] = yaclib::MakeSharedContract<int>();
+  ASSERT_EQ(sp1.Valid(), true);
+
+  auto sp2 = std::move(sp1);
+  ASSERT_EQ(sp1.Valid(), false);
+  ASSERT_EQ(sp2.Valid(), true);
+
+  std::move(sp2).Set(SET_VALUE);
+  ASSERT_EQ(sf.Get().Value(), SET_VALUE);
+}
+
+TEST(SharedCore, SharedFutureGet) {
+  yaclib::FairThreadPool tp;
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+  yaclib::Submit(tp, [sp = std::move(sp)]() mutable {
+    std::move(sp).Set(SET_VALUE);
+  });
+
+  ASSERT_EQ(sf.Get().Value(), SET_VALUE);
+  ASSERT_EQ(sf.GetFuture().Get().Value(), SET_VALUE);
+
+  tp.SoftStop();
+  tp.Wait();
+}
+
+TEST(SharedCore, SharedFutureConcurrentGet) {
+  yaclib::FairThreadPool tp;
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+  yaclib::Submit(tp, [sp = std::move(sp)]() mutable {
+    std::move(sp).Set(SET_VALUE);
+  });
+
+  yaclib::FairThreadPool tp2;
+  for (size_t i = 0; i < 10; ++i) {
+    yaclib::Submit(tp2, [&sf = sf]() mutable {
+      ASSERT_EQ(sf.Get().Value(), SET_VALUE);
+    });
+  }
+
+  tp.SoftStop();
+  tp.Wait();
+
+  tp2.SoftStop();
+  tp2.Wait();
+}
+
+}  // namespace
+}  // namespace test

--- a/test/unit/async/shared_core.cpp
+++ b/test/unit/async/shared_core.cpp
@@ -13,7 +13,7 @@
 namespace test {
 namespace {
 
-constexpr int SET_VALUE = 5;
+constexpr int kSetValue = 5;
 
 TEST(SharedCore, Void) {
   auto [sf, sp] = yaclib::MakeSharedContract<>();
@@ -23,22 +23,22 @@ TEST(SharedCore, Void) {
 
 TEST(SharedCore, SetGet) {
   auto [sf, sp] = yaclib::MakeSharedContract<int>();
-  std::move(sp).Set(SET_VALUE);
-  EXPECT_EQ(sf.Get().Value(), SET_VALUE);
+  std::move(sp).Set(kSetValue);
+  EXPECT_EQ(sf.Get().Value(), kSetValue);
 }
 
 TEST(SharedCore, SetGetFuture) {
   auto [sf, sp] = yaclib::MakeSharedContract<int>();
-  std::move(sp).Set(SET_VALUE);
+  std::move(sp).Set(kSetValue);
   auto f = sf.GetFuture();
-  EXPECT_EQ(std::move(f).Get().Value(), SET_VALUE);
+  EXPECT_EQ(std::move(f).Get().Value(), kSetValue);
 }
 
 TEST(SharedCore, GetFutureSet) {
   auto [sf, sp] = yaclib::MakeSharedContract<int>();
   auto f = sf.GetFuture();
-  std::move(sp).Set(SET_VALUE);
-  EXPECT_EQ(std::move(f).Get().Value(), SET_VALUE);
+  std::move(sp).Set(kSetValue);
+  EXPECT_EQ(std::move(f).Get().Value(), kSetValue);
 }
 
 TEST(SharedCore, GetFutureOn) {
@@ -47,10 +47,10 @@ TEST(SharedCore, GetFutureOn) {
   auto [sf, sp] = yaclib::MakeSharedContract<int>();
   auto f = sf.GetFutureOn(tp);
   std::move(f).Detach([](int value) {
-    EXPECT_EQ(value, SET_VALUE);
+    EXPECT_EQ(value, kSetValue);
   });
 
-  std::move(sp).Set(SET_VALUE);
+  std::move(sp).Set(kSetValue);
 
   tp.SoftStop();
   tp.Wait();
@@ -61,12 +61,12 @@ TEST(SharedCore, PromiseDtor) {
 
   {
     auto [sf_internal, sp_internal] = yaclib::MakeSharedContract<int>();
-    std::move(sp_internal).Set(SET_VALUE);
+    std::move(sp_internal).Set(kSetValue);
     sf = sf_internal;
   }
 
   auto f1 = sf.GetFuture();
-  EXPECT_EQ(std::move(f1).Get().Value(), SET_VALUE);
+  EXPECT_EQ(std::move(f1).Get().Value(), kSetValue);
 
   {
     auto [sf_internal, sp_internal] = yaclib::MakeSharedContract<int>();
@@ -81,9 +81,9 @@ TEST(SharedCore, PromiseAttach) {
   auto [f, p] = yaclib::MakeContract<int>();
 
   sf.Attach(std::move(p));
-  std::move(sp).Set(SET_VALUE);
+  std::move(sp).Set(kSetValue);
 
-  EXPECT_EQ(std::move(f).Get().Value(), SET_VALUE);
+  EXPECT_EQ(std::move(f).Get().Value(), kSetValue);
 }
 
 TEST(SharedCore, Concurrent) {
@@ -94,13 +94,13 @@ TEST(SharedCore, Concurrent) {
   for (size_t i = 0; i < 10; ++i) {
     yaclib::Submit(tp, [&sf = sf, &tp]() {
       sf.GetFuture().Detach(tp, [](int value) {
-        EXPECT_EQ(value, SET_VALUE);
+        EXPECT_EQ(value, kSetValue);
       });
     });
   }
 
   yaclib::Submit(tp, [sp = std::move(sp)]() mutable {
-    std::move(sp).Set(SET_VALUE);
+    std::move(sp).Set(kSetValue);
   });
 
   tp.SoftStop();
@@ -124,8 +124,8 @@ TEST(SharedCore, FuturesOutliveShared) {
     f = sf.GetFuture();
   }
 
-  std::move(sp).Set(SET_VALUE);
-  EXPECT_EQ(std::move(f).Get().Value(), SET_VALUE);
+  std::move(sp).Set(kSetValue);
+  EXPECT_EQ(std::move(f).Get().Value(), kSetValue);
 }
 
 TEST(SharedCore, CopySharedFuture) {
@@ -139,10 +139,10 @@ TEST(SharedCore, CopySharedFuture) {
   auto f1 = sf1.GetFuture();
   auto f2 = sf2.GetFuture();
 
-  std::move(sp).Set(SET_VALUE);
+  std::move(sp).Set(kSetValue);
 
-  ASSERT_EQ(std::move(f1).Get().Value(), SET_VALUE);
-  ASSERT_EQ(std::move(f2).Get().Value(), SET_VALUE);
+  ASSERT_EQ(std::move(f1).Get().Value(), kSetValue);
+  ASSERT_EQ(std::move(f2).Get().Value(), kSetValue);
 }
 
 TEST(SharedCore, MoveSharedFuture) {
@@ -153,8 +153,8 @@ TEST(SharedCore, MoveSharedFuture) {
   ASSERT_EQ(sf1.Valid(), false);
   ASSERT_EQ(sf2.Valid(), true);
 
-  std::move(sp).Set(SET_VALUE);
-  ASSERT_EQ(sf2.Get().Value(), SET_VALUE);
+  std::move(sp).Set(kSetValue);
+  ASSERT_EQ(sf2.Get().Value(), kSetValue);
 }
 
 TEST(SharedCore, MoveSharedPromise) {
@@ -165,19 +165,19 @@ TEST(SharedCore, MoveSharedPromise) {
   ASSERT_EQ(sp1.Valid(), false);
   ASSERT_EQ(sp2.Valid(), true);
 
-  std::move(sp2).Set(SET_VALUE);
-  ASSERT_EQ(sf.Get().Value(), SET_VALUE);
+  std::move(sp2).Set(kSetValue);
+  ASSERT_EQ(sf.Get().Value(), kSetValue);
 }
 
 TEST(SharedCore, SharedFutureGet) {
   yaclib::FairThreadPool tp;
   auto [sf, sp] = yaclib::MakeSharedContract<int>();
   yaclib::Submit(tp, [sp = std::move(sp)]() mutable {
-    std::move(sp).Set(SET_VALUE);
+    std::move(sp).Set(kSetValue);
   });
 
-  ASSERT_EQ(sf.Get().Value(), SET_VALUE);
-  ASSERT_EQ(sf.GetFuture().Get().Value(), SET_VALUE);
+  ASSERT_EQ(sf.Get().Value(), kSetValue);
+  ASSERT_EQ(sf.GetFuture().Get().Value(), kSetValue);
 
   tp.SoftStop();
   tp.Wait();
@@ -187,13 +187,13 @@ TEST(SharedCore, SharedFutureConcurrentGet) {
   yaclib::FairThreadPool tp;
   auto [sf, sp] = yaclib::MakeSharedContract<int>();
   yaclib::Submit(tp, [sp = std::move(sp)]() mutable {
-    std::move(sp).Set(SET_VALUE);
+    std::move(sp).Set(kSetValue);
   });
 
   yaclib::FairThreadPool tp2;
   for (size_t i = 0; i < 10; ++i) {
     yaclib::Submit(tp2, [&sf = sf]() mutable {
-      ASSERT_EQ(sf.Get().Value(), SET_VALUE);
+      ASSERT_EQ(sf.Get().Value(), kSetValue);
     });
   }
 


### PR DESCRIPTION
### Purpose
This PR adds the `SharedFuture` and `SharedPromise` classes, representing the single-producer multiple-consumer one-shot one-element channel. `SharedFuture` can be used to create multiple instances of `Future` all of which will be fulfilled with the same copyable value as soon as the corresponding `SharedPromise` is set.
 
