### PR TITLE
Update clang-format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run clang-format style check
-        uses: jidicula/clang-format-action@v4.13.0
+        uses: jidicula/clang-format-action@v4.15.0
         with:
-          clang-format-version: 17
+          clang-format-version: 20
           check-path: ${{ matrix.path }}

--- a/include/yaclib/algo/detail/base_core.hpp
+++ b/include/yaclib/algo/detail/base_core.hpp
@@ -52,7 +52,7 @@ class BaseCore : public InlineCore {
   [[nodiscard]] virtual yaclib_std::coroutine_handle<> Curr() noexcept {  // LCOV_EXCL_LINE
     YACLIB_PURE_VIRTUAL();                                                // LCOV_EXCL_LINE
     return {};                                                            // LCOV_EXCL_LINE
-  }                                                                       // LCOV_EXCL_LINE
+  }  // LCOV_EXCL_LINE
 #endif
 
  protected:

--- a/include/yaclib/exe/job.hpp
+++ b/include/yaclib/exe/job.hpp
@@ -14,7 +14,7 @@ class Job : public IFunc, public detail::Node {
   // Compiler inline this call in tests
   virtual void Drop() noexcept {  // LCOV_EXCL_LINE
     YACLIB_PURE_VIRTUAL();        // LCOV_EXCL_LINE
-  }                               // LCOV_EXCL_LINE
+  }  // LCOV_EXCL_LINE
 };
 
 }  // namespace yaclib

--- a/include/yaclib/util/detail/unique_counter.hpp
+++ b/include/yaclib/util/detail/unique_counter.hpp
@@ -17,7 +17,7 @@ struct OneCounter : CounterBase {
 
   // compiler remove this call from code
   void Add(std::size_t) noexcept {  // LCOV_EXCL_LINE
-  }                                 // LCOV_EXCL_LINE
+  }  // LCOV_EXCL_LINE
 
   void Sub(std::size_t) noexcept {
     Deleter::Delete(*this);

--- a/include/yaclib/util/func.hpp
+++ b/include/yaclib/util/func.hpp
@@ -15,7 +15,7 @@ class IFunc : public IRef {  // TODO(MBkkt) Maybe remove inheritance from IRef
   // compiler remove this call from tests
   virtual void Call() noexcept {  // LCOV_EXCL_LINE
     YACLIB_PURE_VIRTUAL();        // LCOV_EXCL_LINE
-  }                               // LCOV_EXCL_LINE
+  }  // LCOV_EXCL_LINE
 };
 
 }  // namespace yaclib

--- a/test/unit/async/connect.cpp
+++ b/test/unit/async/connect.cpp
@@ -102,11 +102,13 @@ TEST(Connect, SetSharedAfterContract) {
 TEST(Connect, ConnectLoops) {
   auto [f1, p1] = yaclib::MakeContract<int>();
   auto [f2, p2] = yaclib::MakeContract<int>();
-  auto f3 = std::move(f2).ThenInline([](int x) {
-    return x + 1;
-  }).ThenInline([](int x) {
-    return x + 1;
-  });
+  auto f3 = std::move(f2)
+              .ThenInline([](int x) {
+                return x + 1;
+              })
+              .ThenInline([](int x) {
+                return x + 1;
+              });
   std::move(p1).Set(kSetInt);
   Connect(std::move(f1), std::move(p2));
   ASSERT_EQ(std::move(f3).Get().Value(), kSetInt + 2);

--- a/test/unit/not_implemented.cpp
+++ b/test/unit/not_implemented.cpp
@@ -77,11 +77,11 @@ void CheckResultCoreImplNonMovable() {
 }
 
 TEST(ResultCore, ImplNonMovable) {
-#  ifndef YACLIB_LOG_DEBUG
+#ifndef YACLIB_LOG_DEBUG
   CheckResultCoreImplNonMovable();
-#  else
+#else
   EXPECT_FATAL_FAILURE(CheckResultCoreImplNonMovable(), "");
-#  endif
+#endif
 }
 
 TEST(UniqueJob, Ref) {


### PR DESCRIPTION
### Purpose

This PR updates clang-format version from 17 to 20 and reformats the code accordingly