### PR TITLE
Add Then for SharedFuture

### DIFF
--- a/include/yaclib/algo/detail/base_core.hpp
+++ b/include/yaclib/algo/detail/base_core.hpp
@@ -35,6 +35,13 @@ class BaseCore : public InlineCore {
     }
   }
 
+  void CopyExecutorTo(BaseCore& callback) noexcept {
+    if (!callback._executor) {
+      YACLIB_ASSERT(_executor != nullptr);
+      callback._executor = _executor;
+    }
+  }
+
 #if YACLIB_CORO != 0                                                      // Compiler inline this call in tests
   [[nodiscard]] virtual yaclib_std::coroutine_handle<> Curr() noexcept {  // LCOV_EXCL_LINE
     YACLIB_PURE_VIRTUAL();                                                // LCOV_EXCL_LINE
@@ -56,6 +63,9 @@ class BaseCore : public InlineCore {
   [[nodiscard]] bool SetCallbackImpl(InlineCore& callback) noexcept;
 
   [[nodiscard]] bool ResetImpl() noexcept;
+
+  template <bool SymmetricTransfer, bool Shared>
+  [[nodiscard]] Transfer<SymmetricTransfer> SetInlineImpl(InlineCore& callback) noexcept;
 
   template <bool SymmetricTransfer, bool Shared>
   [[nodiscard]] Transfer<SymmetricTransfer> SetResultImpl() noexcept;

--- a/include/yaclib/algo/detail/result_core.hpp
+++ b/include/yaclib/algo/detail/result_core.hpp
@@ -4,6 +4,8 @@
 #include <yaclib/util/cast.hpp>
 #include <yaclib/util/result.hpp>
 
+#include <utility>
+
 namespace yaclib::detail {
 
 struct Callback {
@@ -34,6 +36,15 @@ class ResultCore : public BaseCore {
 
   [[nodiscard]] Result<V, E>& Get() noexcept {
     return _result;
+  }
+
+  template <bool Condition>
+  decltype(auto) MoveOrConst() {
+    if constexpr (Condition) {
+      return std::move(Get());
+    } else {
+      return std::as_const(Get());
+    }
   }
 
   union {

--- a/include/yaclib/algo/detail/shared_core.hpp
+++ b/include/yaclib/algo/detail/shared_core.hpp
@@ -23,6 +23,15 @@ class SharedCore : public ResultCore<V, E> {
     return BaseCore::SetCallbackImpl<true>(callback);
   }
 
+  // Users should be cautious calling SetInline on a SharedCore
+  // because the core's lifetime is managed by the SharedPromise and
+  // SharedFutures and they might all be gone by the time
+  // the callback is called
+  template <bool SymmetricTransfer>
+  [[nodiscard]] Transfer<SymmetricTransfer> SetInline(InlineCore& callback) noexcept {
+    return BaseCore::SetInlineImpl<SymmetricTransfer, true>(callback);
+  }
+
   template <bool SymmetricTransfer>
   [[nodiscard]] Transfer<SymmetricTransfer> SetResult() noexcept {
     return BaseCore::SetResultImpl<SymmetricTransfer, true>();

--- a/include/yaclib/algo/detail/unique_core.hpp
+++ b/include/yaclib/algo/detail/unique_core.hpp
@@ -37,10 +37,7 @@ class UniqueCore : public ResultCore<V, E> {
 
   template <bool SymmetricTransfer>
   [[nodiscard]] Transfer<SymmetricTransfer> SetInline(InlineCore& callback) noexcept {
-    if (!SetCallback(callback)) {
-      return Step<SymmetricTransfer>(*this, callback);
-    }
-    return Noop<SymmetricTransfer>();
+    return BaseCore::SetInlineImpl<SymmetricTransfer, false>(callback);
   }
 
   template <bool SymmetricTransfer>

--- a/include/yaclib/async/run.hpp
+++ b/include/yaclib/async/run.hpp
@@ -14,7 +14,7 @@ template <typename V = Unit, typename E = StopError, typename Func>
 YACLIB_INLINE auto Run(IExecutor& e, Func&& f) {
   auto* core = [&] {
     if constexpr (std::is_same_v<V, Unit>) {
-      return MakeCore<CoreType::Run, true, void, E>(std::forward<Func>(f));
+      return MakeCore<CoreType::Run, true, false, void, E>(std::forward<Func>(f));
     } else {
       return MakeUnique<PromiseCore<V, E, Func&&>>(std::forward<Func>(f)).Release();
     }

--- a/include/yaclib/lazy/schedule.hpp
+++ b/include/yaclib/lazy/schedule.hpp
@@ -9,7 +9,7 @@ template <typename V, typename E, typename Func>
 YACLIB_INLINE auto Schedule(IExecutor& e, Func&& f) {
   auto* core = [&] {
     if constexpr (std::is_same_v<V, Unit>) {
-      return MakeCore<CoreType::Run, true, void, E>(std::forward<Func>(f));
+      return MakeCore<CoreType::Run, true, false, void, E>(std::forward<Func>(f));
     } else {
       return MakeUnique<PromiseCore<V, E, Func&&>>(std::forward<Func>(f)).Release();
     }

--- a/include/yaclib/util/detail/type_traits_impl.hpp
+++ b/include/yaclib/util/detail/type_traits_impl.hpp
@@ -80,4 +80,16 @@ struct FutureBaseTypes<FutureOn<V, E>> final {
   using Error = E;
 };
 
+template <typename T>
+struct SharedFutureTypes final {
+  using Value = T;
+  using Error = T;
+};
+
+template <typename V, typename E>
+struct FutureBaseTypes<SharedFuture<V, E>> final {
+  using Value = V;
+  using Error = E;
+};
+
 }  // namespace yaclib::detail

--- a/include/yaclib/util/type_traits.hpp
+++ b/include/yaclib/util/type_traits.hpp
@@ -64,6 +64,12 @@ using future_base_value_t = typename detail::FutureBaseTypes<T>::Value;  // NOLI
 template <typename T>
 using future_base_error_t = typename detail::FutureBaseTypes<T>::Error;  // NOLINT
 
+template <typename T>
+using shared_future_value_t = typename detail::SharedFutureTypes<T>::Value;  // NOLINT
+
+template <typename T>
+using shared_future_error_t = typename detail::SharedFutureTypes<T>::Error;  // NOLINT
+
 template <bool Condition, typename T>
 decltype(auto) move_if(T&& arg) noexcept {  // NOLINT
   if constexpr (Condition) {

--- a/src/algo/base_core.cpp
+++ b/src/algo/base_core.cpp
@@ -34,6 +34,22 @@ template bool BaseCore::SetCallbackImpl<true>(InlineCore&) noexcept;
 }
 
 template <bool SymmetricTransfer, bool Shared>
+[[nodiscard]] Transfer<SymmetricTransfer> BaseCore::SetInlineImpl(InlineCore& callback) noexcept {
+  if (!SetCallbackImpl<Shared>(callback)) {
+    return Step<SymmetricTransfer>(*this, callback);
+  }
+  return Noop<SymmetricTransfer>();
+}
+
+template Transfer<false> BaseCore::SetInlineImpl<false, false>(InlineCore&) noexcept;
+template Transfer<false> BaseCore::SetInlineImpl<false, true>(InlineCore&) noexcept;
+
+#if YACLIB_SYMMETRIC_TRANSFER != 0
+template Transfer<true> BaseCore::SetInlineImpl<true, false>(InlineCore&) noexcept;
+template Transfer<true> BaseCore::SetInlineImpl<true, true>(InlineCore&) noexcept;
+#endif
+
+template <bool SymmetricTransfer, bool Shared>
 [[nodiscard]] Transfer<SymmetricTransfer> BaseCore::SetResultImpl() noexcept {
   const auto expected = _callback.exchange(kResult, std::memory_order_acq_rel);
   YACLIB_ASSERT(expected != kResult);

--- a/test/unit/async/core_size.cpp
+++ b/test/unit/async/core_size.cpp
@@ -59,7 +59,7 @@ void kek() {
 }
 
 TEST(Core, EmptySizeof) {
-  auto* core = yaclib::detail::MakeCore<yaclib::detail::CoreType::Run, true, void, yaclib::StopError>([] {
+  auto* core = yaclib::detail::MakeCore<yaclib::detail::CoreType::Run, true, false, void, yaclib::StopError>([] {
     kek();
   });
 
@@ -74,7 +74,7 @@ TEST(Core, EmptySizeof) {
 }
 
 TEST(Core, Sizeof) {
-  auto* core = yaclib::detail::MakeCore<yaclib::detail::CoreType::Run, true, void, yaclib::StopError>(kek);
+  auto* core = yaclib::detail::MakeCore<yaclib::detail::CoreType::Run, true, false, void, yaclib::StopError>(kek);
   static_assert(sizeof(void*) == sizeof(int) || sizeof(*core) == (sizeof(yaclib::detail::BaseCore) +  //
                                                                   sizeof(yaclib::Result<>) +          //
                                                                   sizeof(&kek) +                      //


### PR DESCRIPTION
### Purpose

This PR adds the ability to set up callbacks on a `SharedFuture` (`SharedFuture::Then/ThenInline`). The future is not consumed in the process.
