### PR TITLE
Make ResultCore move result from shared caller when possible

### DIFF
--- a/include/yaclib/algo/detail/result_core.hpp
+++ b/include/yaclib/algo/detail/result_core.hpp
@@ -44,26 +44,30 @@ class ResultCore : public BaseCore {
  protected:
   template <bool SymmetricTransfer, bool Shared>
   [[nodiscard]] YACLIB_INLINE auto Impl(InlineCore& caller) noexcept {
-    if constexpr (std::is_move_constructible_v<Result<V, E>>) {
-      auto refcount = caller.GetRef();
-      if constexpr (std::is_copy_constructible_v<Result<V, E>>) {
-        if (refcount >= 3) {
-          // SharedCore, SharedFutures exist and/or not the last callback in the list
-          // the value may not be moved
-          ResultCore<V, E>::Store(DownCast<ResultCore<V, E>>(caller).Get());
-          return BaseCore::SetResultImpl<SymmetricTransfer, Shared>();
-        }
+    if constexpr (std::is_copy_constructible_v<Result<V, E>>) {
+      // Copy values can come from both Unique and Shared cores
+      const auto ref = caller.GetRef();
+      if (ref >= 3) {
+        // This is a Shared core and Shared futures exist and/or not
+        // the last callback in the list, the value may not be moved
+        ResultCore<V, E>::Store(DownCast<ResultCore<V, E>>(caller).Get());
+        return BaseCore::SetResultImpl<SymmetricTransfer, Shared>();
       }
-      // refcount 1 : UniqueCore, move the value and destroy the core
-      // refcount 2 : SharedCore, no more SharedFutures exist and the last callback in the list,
-      // move the value but let the core destroy itself
-      YACLIB_ASSERT(refcount == 1 || refcount == 2);
+      // ref == 1: This is a Unique core, move the value and destroy the core
+      // ref == 2: This is a Shared core, no more SharedFutures exist and the
+      // last callback in the list, move the value but do not destroy the core
       ResultCore<V, E>::Store(std::move(DownCast<ResultCore<V, E>>(caller).Get()));
-      if (refcount == 1) {
+      if (ref == 1) {
         caller.DecRef();
       }
       return BaseCore::SetResultImpl<SymmetricTransfer, Shared>();
+    } else if constexpr (std::is_move_constructible_v<Result<V, E>>) {
+      // Move-only values are from Unique cores only
+      ResultCore<V, E>::Store(std::move(DownCast<ResultCore<V, E>>(caller).Get()));
+      caller.DecRef();
+      return BaseCore::SetResultImpl<SymmetricTransfer, Shared>();
     } else {
+      // Unreachable, cannot set callbacks on immovable cores
       YACLIB_PURE_VIRTUAL();
       return Noop<SymmetricTransfer>();
     }

--- a/include/yaclib/async/shared_contract.hpp
+++ b/include/yaclib/async/shared_contract.hpp
@@ -13,8 +13,8 @@ using SharedContract = std::pair<SharedFuture<V, E>, SharedPromise<V, E>>;
 
 template <typename V = void, typename E = StopError>
 [[nodiscard]] SharedContract<V, E> MakeSharedContract() {
-  // 2 refs for SharedPromise, 1 ref for SharedFuture
-  auto core = MakeShared<detail::SharedCore<V, E>>(3);
+  // 3 refs for SharedPromise, 1 ref for SharedFuture
+  auto core = MakeShared<detail::SharedCore<V, E>>(4);
   SharedFuture<V, E> future{detail::SharedCorePtr<V, E>{NoRefTag{}, core.Get()}};
   SharedPromise<V, E> promise{detail::SharedCorePtr<V, E>{NoRefTag{}, core.Release()}};
   return {std::move(future), std::move(promise)};

--- a/include/yaclib/async/shared_contract.hpp
+++ b/include/yaclib/async/shared_contract.hpp
@@ -13,7 +13,8 @@ using SharedContract = std::pair<SharedFuture<V, E>, SharedPromise<V, E>>;
 
 template <typename V = void, typename E = StopError>
 [[nodiscard]] SharedContract<V, E> MakeSharedContract() {
-  // 3 refs for SharedPromise, 1 ref for SharedFuture
+  // 3 refs for the promise (1 for the promise itself and 2 for the last callback)
+  // 1 ref for the future
   auto core = MakeShared<detail::SharedCore<V, E>>(4);
   SharedFuture<V, E> future{detail::SharedCorePtr<V, E>{NoRefTag{}, core.Get()}};
   SharedPromise<V, E> promise{detail::SharedCorePtr<V, E>{NoRefTag{}, core.Release()}};

--- a/src/algo/base_core.cpp
+++ b/src/algo/base_core.cpp
@@ -39,10 +39,16 @@ template <bool SymmetricTransfer, bool Shared>
   YACLIB_ASSERT(expected != kResult);
   if constexpr (Shared) {
     auto* head = reinterpret_cast<InlineCore*>(expected);
-    while (head) {
+    while (head && head->next) {
       auto next = head->next;
       Loop(this, head);
       head = static_cast<InlineCore*>(next);
+    }
+    DecRef();
+    if (head) {
+      // If the refcount here is 2, the callback is the last one for this core
+      // (no shared futures left), so the value may be moved
+      Loop(this, head);
     }
     DecRef();
     DecRef();

--- a/src/algo/base_core.cpp
+++ b/src/algo/base_core.cpp
@@ -39,16 +39,17 @@ template <bool SymmetricTransfer, bool Shared>
   YACLIB_ASSERT(expected != kResult);
   if constexpr (Shared) {
     auto* head = reinterpret_cast<InlineCore*>(expected);
-    while (head && head->next) {
-      auto next = head->next;
-      Loop(this, head);
-      head = static_cast<InlineCore*>(next);
-    }
-    DecRef();
     if (head) {
-      // If the refcount here is 2, the callback is the last one for this core
-      // (no shared futures left), so the value may be moved
+      while (auto* next = head->next) {
+        Loop(this, head);
+        head = static_cast<InlineCore*>(next);
+      }
+      DecRef();
+      // If the refcount here is 2, the callback is the last one for
+      // this core (no Shared futures left), so the value may be moved
       Loop(this, head);
+    } else {
+      DecRef();
     }
     DecRef();
     DecRef();

--- a/test/unit/async/connect.cpp
+++ b/test/unit/async/connect.cpp
@@ -114,5 +114,23 @@ TEST(Connect, ConnectLoops) {
   ASSERT_EQ(std::move(f3).Get().Value(), kSetInt + 2);
 }
 
+struct MoveOnly {
+  MoveOnly() = default;
+
+  MoveOnly(const MoveOnly&) = delete;
+  MoveOnly(MoveOnly&&) = default;
+
+  MoveOnly& operator=(const MoveOnly&) = delete;
+  MoveOnly& operator=(MoveOnly&&) = default;
+};
+
+TEST(Connect, MoveOnly) {
+  auto [f1, p1] = yaclib::MakeContract<MoveOnly>();
+  auto [f2, p2] = yaclib::MakeContract<MoveOnly>();
+  doConnect(f1, p2);
+  std::move(p1).Set();
+  std::ignore = std::move(f2).Get().Value();
+}
+
 }  // namespace
 }  // namespace test


### PR DESCRIPTION
This PR makes callback `UniqueCore/SharedCore` instances move the result from the caller `SharedCore` when they are the last callback to ever need the value