### PR TITLE
Shared core callbacks own their references

### DIFF
--- a/include/yaclib/algo/detail/base_core.hpp
+++ b/include/yaclib/algo/detail/base_core.hpp
@@ -29,6 +29,12 @@ class BaseCore : public InlineCore {
     return callback == kEmpty;
   }
 
+  // Not Empty() is the wrong readiness check for shared cores:
+  // the callback word also holds the attached callback list
+  bool Ready() const noexcept {
+    return _callback.load(std::memory_order_acquire) == kResult;
+  }
+
   template <bool Shared>
   void TransferExecutorTo(BaseCore& callback) noexcept {
     if (!callback._executor) {

--- a/include/yaclib/algo/detail/core.hpp
+++ b/include/yaclib/algo/detail/core.hpp
@@ -114,6 +114,7 @@ class Core : public ResultCoreT<Type, Ret, T>, public FuncCore<Func> {
   using Invoke = typename F::Invoke;
 
   static_assert(!(IsDetach(Type) && kAsync != AsyncType::None), "Detach cannot be Async, should be void");
+  static_assert(!(IsDetach(Type) && kAsync != AsyncType::None), "Detach cannot be Async, should be void");
 
  public:
   using Base = ResultCoreT<Type, Ret, T>;
@@ -164,11 +165,6 @@ class Core : public ResultCoreT<Type, Ret, T>, public FuncCore<Func> {
       YACLIB_ASSERT(this->_self.caller == nullptr);
       this->_self.caller = &caller;
       DownCast<BaseCore>(caller).TransferExecutorTo<IsFromShared(Type)>(*this);
-      if constexpr (IsFromShared(Type) && (IsCall(Type) || kAsync != AsyncType::None)) {
-        // The callback can outlive all SharedFutures
-        // We assume ownership here and release it in Done()
-        caller.IncRef();
-      }
       if constexpr (IsCall(Type)) {
         this->_executor->Submit(*this);
         return Noop<SymmetricTransfer>();
@@ -213,16 +209,10 @@ class Core : public ResultCoreT<Type, Ret, T>, public FuncCore<Func> {
     auto* caller = this->_self.caller;
     this->Store(std::forward<R>(value));
 
-    // We decrease the reference count in the following cases:
-    // If !Async (We are now not called by the async result of our callback), then:
-    //   !Type & Run : We are not the first callback in the chain so there is a previous core AND:
-    //     Type & FromUnique : The previous core is a UniqueCore, we always have ownership
-    //     OR we have might have a SharedCore as the previous core and in that case:
-    //       Type & Call : Our callback can outlive the previous core OR
-    //       kAsync != AsyncType::None: Async operation of our callback can outlive the previous core
-    //       - So in the last two cases, we assume ownership of the SharedCore beforehand and release it here
-    // If Async, then we always have ownership of the async result of our callback
-    if constexpr ((!IsRun(Type) && (IsFromUnique(Type) || IsCall(Type) || kAsync != AsyncType::None)) || Async) {
+    // We always own one reference on the previous core: transferred from the future
+    // for FromUnique, granted at attach for FromShared, and if Async we own the
+    // async result core of our callback, so release it here
+    if constexpr (!IsRun(Type) || Async) {
       caller->DecRef();
     }
     if constexpr (!Async) {
@@ -394,6 +384,9 @@ auto SetCallback(FromCorePtr&& core, IExecutor* executor, Func&& f) {
     if constexpr (Unique) {
       return core.Release();
     } else {
+      // Grant the callback its reference on the core, it is released when
+      // the callback is done reading, in both attached and immediate paths
+      core->IncRef();
       return core.Get();
     }
   }();

--- a/include/yaclib/algo/detail/result_core.hpp
+++ b/include/yaclib/algo/detail/result_core.hpp
@@ -65,22 +65,16 @@ class ResultCore : public BaseCore {
  protected:
   template <bool SymmetricTransfer, bool Shared>
   [[nodiscard]] YACLIB_INLINE auto Impl(InlineCore& caller) noexcept {
+    // This callback owns one reference on the caller: transferred from the future
+    // for Unique cores, granted at attach for Shared ones. The refcount is exactly
+    // the number of entities that can still read the caller, so 1 means sole reader
     if constexpr (std::is_copy_constructible_v<wrap_void_t<V>>) {
-      // Copy values can come from both Unique and Shared cores
-      const auto ref = caller.GetRef();
-      if (ref >= 3) {
-        // This is a Shared core and Shared futures exist and/or not
-        // the last callback in the list, the value may not be moved
+      if (caller.GetRef() > 1) {
         ResultCore<V, T>::Store(DownCast<ResultCore<V, T>>(caller).Get());
-        return BaseCore::SetResultImpl<SymmetricTransfer, Shared>();
+      } else {
+        ResultCore<V, T>::Store(std::move(DownCast<ResultCore<V, T>>(caller).Get()));
       }
-      // ref == 1: This is a Unique core, move the value and destroy the core
-      // ref == 2: This is a Shared core, no more SharedFutures exist and the
-      // last callback in the list, move the value but do not destroy the core
-      ResultCore<V, T>::Store(std::move(DownCast<ResultCore<V, T>>(caller).Get()));
-      if (ref == 1) {
-        caller.DecRef();
-      }
+      caller.DecRef();
       return BaseCore::SetResultImpl<SymmetricTransfer, Shared>();
     } else if constexpr (std::is_move_constructible_v<wrap_void_t<V>>) {
       // Move-only values are from Unique cores only

--- a/include/yaclib/algo/detail/shared_core.hpp
+++ b/include/yaclib/algo/detail/shared_core.hpp
@@ -4,10 +4,11 @@
 
 namespace yaclib::detail {
 
-// 3 refs for the promise (1 for the promise itself and 2 for the last callback)
-// 1 ref for the future
-inline constexpr std::size_t kSharedRefWithFuture = 4;
-inline constexpr std::size_t kSharedRefNoFuture = 3;
+// 1 ref for the promise, 1 ref for the future.
+// Every attached callback additionally owns 1 ref, granted at attach,
+// released by the callback when it is done reading the core
+inline constexpr std::size_t kSharedRefWithFuture = 2;
+inline constexpr std::size_t kSharedRefNoFuture = 1;
 
 template <typename V, typename T>
 class SharedCore : public ResultCore<V, T> {

--- a/include/yaclib/async/connect.hpp
+++ b/include/yaclib/async/connect.hpp
@@ -25,9 +25,12 @@ template <typename V, typename T>
 void Connect(const SharedFutureBase<V, T>& f, Promise<V, T>&& p) {
   YACLIB_ASSERT(f.Valid());
   YACLIB_ASSERT(p.Valid());
+  // Grant the callback its reference on the shared core, \see detail::SetCallback
+  f.GetCore()->IncRef();
   if (f.GetCore()->SetCallback(*p.GetCore().Get())) {
     p.GetCore().Release();
   } else {
+    f.GetCore()->DecRef();
     std::move(p).Set(f.Touch());
   }
 }
@@ -49,9 +52,12 @@ void Connect(const SharedFutureBase<V, T>& f, SharedPromise<V, T>&& p) {
   YACLIB_ASSERT(f.Valid());
   YACLIB_ASSERT(p.Valid());
   YACLIB_ASSERT(f.GetCore() != p.GetCore());
+  // Grant the callback its reference on the shared core, \see detail::SetCallback
+  f.GetCore()->IncRef();
   if (f.GetCore()->SetCallback(*p.GetCore().Get())) {
     p.GetCore().Release();
   } else {
+    f.GetCore()->DecRef();
     std::move(p).Set(f.Touch());
   }
 }
@@ -61,7 +67,11 @@ void Connect(SharedPromise<V, T>& primary, Promise<V, T>&& subsumed) {
   YACLIB_ASSERT(primary.Valid());
   YACLIB_ASSERT(subsumed.Valid());
   auto subsumed_core = subsumed.GetCore().Release();
-  std::ignore = primary.GetCore()->SetCallback(*subsumed_core);
+  // Grant the callback its reference on the shared core, \see detail::SetCallback
+  primary.GetCore()->IncRef();
+  // A valid SharedPromise cannot have a result yet, so the attach cannot fail
+  [[maybe_unused]] const bool attached = primary.GetCore()->SetCallback(*subsumed_core);
+  YACLIB_ASSERT(attached);
 }
 
 template <typename V, typename T>
@@ -69,7 +79,11 @@ void Connect(SharedPromise<V, T>& primary, SharedPromise<V, T>&& subsumed) {
   YACLIB_ASSERT(primary.Valid());
   YACLIB_ASSERT(subsumed.Valid());
   auto subsumed_core = subsumed.GetCore().Release();
-  std::ignore = primary.GetCore()->SetCallback(*subsumed_core);
+  // Grant the callback its reference on the shared core, \see detail::SetCallback
+  primary.GetCore()->IncRef();
+  // A valid SharedPromise cannot have a result yet, so the attach cannot fail
+  [[maybe_unused]] const bool attached = primary.GetCore()->SetCallback(*subsumed_core);
+  YACLIB_ASSERT(attached);
 }
 
 }  // namespace yaclib

--- a/include/yaclib/async/shared_contract.hpp
+++ b/include/yaclib/async/shared_contract.hpp
@@ -23,7 +23,7 @@ template <typename V = void, typename T = DefaultTrait>
 }
 
 template <typename V = void, typename T = DefaultTrait>
-[[nodiscard]] SharedContract<V, T> MakeSharedContractOn(IExecutor& e) {
+[[nodiscard]] SharedContractOn<V, T> MakeSharedContractOn(IExecutor& e) {
   auto core = MakeShared<detail::SharedCore<V, T>>(detail::kSharedRefWithFuture);
   e.IncRef();
   core->_executor.Reset(NoRefTag{}, &e);

--- a/include/yaclib/async/shared_future.hpp
+++ b/include/yaclib/async/shared_future.hpp
@@ -30,7 +30,7 @@ class SharedFutureBase {
 
   [[nodiscard]] bool Ready() const noexcept {
     YACLIB_ASSERT(Valid());
-    return !_core->Empty();
+    return _core->Ready();
   }
 
   [[nodiscard]] Result Get() && noexcept {

--- a/include/yaclib/coro/detail/await_awaiter.hpp
+++ b/include/yaclib/coro/detail/await_awaiter.hpp
@@ -73,7 +73,7 @@ struct AwaitAwaiterBase {
   }
 
   YACLIB_INLINE bool await_ready() const noexcept {
-    return !_core->Empty();
+    return _core->Ready();
   }
 
   constexpr void await_resume() const noexcept {
@@ -208,7 +208,7 @@ class [[nodiscard]] AwaitSingleAwaiter<false, V, T> final {
   }
 
   YACLIB_INLINE bool await_ready() const noexcept {
-    return !_result->Empty();
+    return _result->Ready();
   }
 
   template <typename Promise>
@@ -233,7 +233,7 @@ class [[nodiscard]] AwaitSingleAwaiter<true, V, T> final {
   }
 
   YACLIB_INLINE bool await_ready() const noexcept {
-    return !_result->Empty();
+    return _result->Ready();
   }
 
   template <typename Promise>

--- a/include/yaclib/coro/detail/promise_type.hpp
+++ b/include/yaclib/coro/detail/promise_type.hpp
@@ -122,7 +122,9 @@ class PromiseType final : public PromiseTypeBase<V, T, Lazy, Shared> {
   }
 
   YACLIB_INLINE void Impl(InlineCore& caller) noexcept {
-    this->_executor = std::move(DownCast<BaseCore>(caller)._executor);
+    // Copy, not move: a shared caller resumes every awaiting coroutine,
+    // moving would leave the wrong executor for all but the first one
+    this->_executor = DownCast<BaseCore>(caller)._executor;
     YACLIB_ASSERT(this->_executor != nullptr);
   }
   [[nodiscard]] InlineCore* Here(InlineCore& caller) noexcept final {

--- a/src/algo/base_core.cpp
+++ b/src/algo/base_core.cpp
@@ -55,20 +55,19 @@ template <bool SymmetricTransfer, bool Shared>
   YACLIB_ASSERT(expected != kResult);
   if constexpr (Shared) {
     auto* head = reinterpret_cast<InlineCore*>(expected);
+    // Producer's own reference. Every callback that reads this core owns one
+    // reference (granted at attach, released by the callback when it is done),
+    // signal only callbacks (wait/await events) read nothing and own nothing.
+    // The walk itself never touches the core after the last callback, which
+    // may release the last reference
+    DecRef();
     if (head) {
       while (auto* next = head->next) {
         Loop(this, head);
         head = static_cast<InlineCore*>(next);
       }
-      DecRef();
-      // If the refcount here is 2, the callback is the last one for
-      // this core (no Shared futures left), so the value may be moved
       Loop(this, head);
-    } else {
-      DecRef();
     }
-    DecRef();
-    DecRef();
     return Noop<SymmetricTransfer>();
   } else {
     if (expected != kEmpty) {

--- a/test/unit/algo/when_all.cpp
+++ b/test/unit/algo/when_all.cpp
@@ -580,11 +580,11 @@ TEST(WhenAll, NoneRetireMovesFinishedSharedCores) {
   std::move(sp2).Set(Counting{&last});
   auto result = std::move(all).Get();
   ASSERT_TRUE(result);
-  // Retire moves from a core whose delivery already finished
+  // The combinator strategy is the sole owner at Retire time for every input,
+  // including the one whose delivery triggered the combinator destruction:
+  // callbacks own their references and the core holds none on itself
   EXPECT_EQ(first, 0);
-  // The input that triggers the combinator destruction is retired inside its own
-  // delivery, where the core still holds the last callback refs, so it's copied
-  EXPECT_EQ(last, 1);
+  EXPECT_EQ(last, 0);
 }
 
 TEST(WhenAll, NoneRetiresLiveSharedCore) {

--- a/test/unit/async/shared_future.cpp
+++ b/test/unit/async/shared_future.cpp
@@ -1,5 +1,6 @@
 #include <yaclib/async/contract.hpp>
 #include <yaclib/async/future.hpp>
+#include <yaclib/async/make.hpp>
 #include <yaclib/async/promise.hpp>
 #include <yaclib/async/run.hpp>
 #include <yaclib/async/share.hpp>
@@ -578,6 +579,49 @@ TEST(SharedFuture, MultipleWaitDynamic) {
 
   tp.SoftStop();
   tp.Wait();
+}
+
+TEST(SharedFuture, ThenUnwrapping) {
+  // FromShared + Async: the continuation returns a Future, the grant is released
+  // when the caller is swapped for the async result core
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+  auto retained = sf;
+  auto f = sf.ThenInline([](int x) {
+    return yaclib::MakeFuture<int>(x + 1);
+  });
+  std::move(sp).Set(41);
+  EXPECT_EQ(std::move(f).Get().Value(), 42);
+  EXPECT_EQ(retained.Get().Value(), 41);
+}
+
+TEST(SharedFuture, Subscribe) {
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+  int attached = 0;
+  int immediate = 0;
+  // Attached path: the grant is consumed when the callback runs in the dispatch walk
+  sf.SubscribeInline([&](int x) {
+    attached = x;
+  });
+  std::move(sp).Set(5);
+  // Immediate path: the result is already set, the grant accompanies the callback into Step
+  sf.SubscribeInline([&](int x) {
+    immediate = x;
+  });
+  EXPECT_EQ(attached, 5);
+  EXPECT_EQ(immediate, 5);
+  EXPECT_EQ(sf.Get().Value(), 5);
+}
+
+TEST(SharedFuture, DroppedCallbackReleasesCore) {
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+  yaclib::FairThreadPool tp{1};
+  tp.HardStop();
+  tp.Wait();
+  // The executor drops the submitted callback, Core::Drop must still release the grant
+  sf.Subscribe(tp, [](int) {
+  });
+  std::move(sp).Set(5);
+  EXPECT_EQ(sf.Get().Value(), 5);
 }
 
 }  // namespace

--- a/test/unit/async/stress.cpp
+++ b/test/unit/async/stress.cpp
@@ -1,6 +1,7 @@
 #include <yaclib/algo/wait_group.hpp>
 #include <yaclib/async/contract.hpp>
 #include <yaclib/async/future.hpp>
+#include <yaclib/async/shared_contract.hpp>
 #include <yaclib/exe/executor.hpp>
 #include <yaclib/exe/inline.hpp>
 #include <yaclib/runtime/fair_thread_pool.hpp>
@@ -9,6 +10,7 @@
 #include <array>
 #include <cstdint>
 #include <iostream>
+#include <string>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -166,6 +168,25 @@ TEST_F(StressTest, Then) {
   });
   tp.Stop();
   tp.Wait();
+}
+
+TEST(SharedFutureStress, ConcurrentSoleReaderMove) {
+  // The ==1 move decisions in Get()/ResultCore::Impl race the producer dispatch
+  // and a concurrently released second handle, the value must stay intact
+  for (std::size_t i = 0; i != 1000; ++i) {
+    auto [sf, sp] = yaclib::MakeSharedContract<std::string>();
+    auto copy = sf;
+    yaclib_std::thread producer{[p = std::move(sp)]() mutable {
+      std::move(p).Set(std::string(64, 'x'));
+    }};
+    yaclib_std::thread releaser{[c = std::move(copy)]() mutable {
+      std::move(c).Detach();
+    }};
+    auto result = std::move(sf).Get();
+    EXPECT_EQ(std::as_const(result).Value(), std::string(64, 'x'));
+    producer.join();
+    releaser.join();
+  }
 }
 
 }  // namespace

--- a/test/unit/coro/await.cpp
+++ b/test/unit/coro/await.cpp
@@ -113,7 +113,7 @@ TEST(SharedFuture, TwoCoroutinesInheritCallerExecutor) {
                  return yaclib_std::this_thread::get_id();
                }).Get();
   auto [sf, sp] = yaclib::MakeSharedContractOn<int>(tp);
-  auto coro = [](yaclib::SharedFuture<int> shared) -> yaclib::Future<yaclib_std::thread::id> {
+  auto coro = [](yaclib::SharedFutureOn<int> shared) -> yaclib::Future<yaclib_std::thread::id> {
     std::ignore = co_await shared;
     co_await yaclib::kYield;  // reschedules on the coroutine's executor
     co_return yaclib_std::this_thread::get_id();

--- a/test/unit/coro/await.cpp
+++ b/test/unit/coro/await.cpp
@@ -92,11 +92,12 @@ TEST(SharedFuture, TwoCoroutinesAwaitOneShared) {
   // Both coroutines must suspend: with a not Empty readiness check the second one
   // would treat the first one's attached callback as a ready result
   auto [sf, sp] = yaclib::MakeSharedContract<int>();
-  auto coro = [&sf]() -> yaclib::Future<int> {
-    co_return co_await sf;
+  // By value parameter: old clang cannot capture a structured binding in a lambda
+  auto coro = [](yaclib::SharedFuture<int> shared) -> yaclib::Future<int> {
+    co_return co_await shared;
   };
-  auto f1 = coro();
-  auto f2 = coro();
+  auto f1 = coro(sf);
+  auto f2 = coro(sf);
   EXPECT_FALSE(f1.Ready());
   EXPECT_FALSE(f2.Ready());
   std::move(sp).Set(21);
@@ -112,13 +113,13 @@ TEST(SharedFuture, TwoCoroutinesInheritCallerExecutor) {
                  return yaclib_std::this_thread::get_id();
                }).Get();
   auto [sf, sp] = yaclib::MakeSharedContractOn<int>(tp);
-  auto coro = [&sf]() -> yaclib::Future<yaclib_std::thread::id> {
-    std::ignore = co_await sf;
+  auto coro = [](yaclib::SharedFuture<int> shared) -> yaclib::Future<yaclib_std::thread::id> {
+    std::ignore = co_await shared;
     co_await yaclib::kYield;  // reschedules on the coroutine's executor
     co_return yaclib_std::this_thread::get_id();
   };
-  auto f1 = coro();
-  auto f2 = coro();
+  auto f1 = coro(sf);
+  auto f2 = coro(sf);
   std::move(sp).Set(21);
   EXPECT_EQ(std::move(f1).Get().Value(), std::as_const(tp_id).Value());
   EXPECT_EQ(std::move(f2).Get().Value(), std::as_const(tp_id).Value());

--- a/test/unit/coro/await.cpp
+++ b/test/unit/coro/await.cpp
@@ -12,6 +12,7 @@
 #include <yaclib/coro/await.hpp>
 #include <yaclib/coro/await_on.hpp>
 #include <yaclib/coro/on.hpp>
+#include <yaclib/coro/yield.hpp>
 #include <yaclib/exe/manual.hpp>
 #include <yaclib/lazy/make.hpp>
 #include <yaclib/runtime/fair_thread_pool.hpp>
@@ -86,6 +87,44 @@ TYPED_TEST(AsyncSuite, JustWorksCoAwait) {
 }
 
 constexpr std::string_view kSetString = "aaa-aaa-aaa-aaa-aaa-aaa-aaa-aaa-aaa-aaa-aaa";
+
+TEST(SharedFuture, TwoCoroutinesAwaitOneShared) {
+  // Both coroutines must suspend: with a not Empty readiness check the second one
+  // would treat the first one's attached callback as a ready result
+  auto [sf, sp] = yaclib::MakeSharedContract<int>();
+  auto coro = [&sf]() -> yaclib::Future<int> {
+    co_return co_await sf;
+  };
+  auto f1 = coro();
+  auto f2 = coro();
+  EXPECT_FALSE(f1.Ready());
+  EXPECT_FALSE(f2.Ready());
+  std::move(sp).Set(21);
+  EXPECT_EQ(std::move(f1).Get().Value(), 21);
+  EXPECT_EQ(std::move(f2).Get().Value(), 21);
+}
+
+TEST(SharedFuture, TwoCoroutinesInheritCallerExecutor) {
+  // Every awaiting coroutine copies the shared caller's executor,
+  // moving would leave the wrong executor for all but the first one
+  yaclib::FairThreadPool tp{1};
+  auto tp_id = yaclib::Run(tp, [] {
+                 return yaclib_std::this_thread::get_id();
+               }).Get();
+  auto [sf, sp] = yaclib::MakeSharedContractOn<int>(tp);
+  auto coro = [&sf]() -> yaclib::Future<yaclib_std::thread::id> {
+    std::ignore = co_await sf;
+    co_await yaclib::kYield;  // reschedules on the coroutine's executor
+    co_return yaclib_std::this_thread::get_id();
+  };
+  auto f1 = coro();
+  auto f2 = coro();
+  std::move(sp).Set(21);
+  EXPECT_EQ(std::move(f1).Get().Value(), std::as_const(tp_id).Value());
+  EXPECT_EQ(std::move(f2).Get().Value(), std::as_const(tp_id).Value());
+  tp.Stop();
+  tp.Wait();
+}
 
 TEST(SharedFuture, JustWorksCoAwaitShared) {
   yaclib::FairThreadPool tp;


### PR DESCRIPTION
### Protocol change

Every callback that reads a shared core owns exactly one reference on it: transferred from the future for unique cores (unchanged), **granted at attach** for shared ones. The core no longer pre-pays references for its own callback dispatch (`kSharedRefWithFuture` 4 → 2, `kSharedRefNoFuture` 3 → 1), and `SetResultImpl<Shared>` releases only the producer reference — before the walk, never touching the core after the last callback.

Consequences:
- `ResultCore::Impl`: the refcount is exactly the number of remaining readers, so the move/copy decision collapses from the `>=3 / ==2 / ==1` ladder to `GetRef() > 1 ? copy : move` with an unconditional release.
- `Core` loses the conditional `FromShared` `IncRef` special case; `Done` releases for any non-`Run` core.
- Combinators, coroutine awaiters and wait events need **no changes**: `Managed` strategies already consume the transferred reference, `Owned` strategies read under their own, signal-only callbacks read nothing.
- **Every input of `WhenAll` over shared futures is now moved on `Retire`**, including the one whose completion destroys the combinator (previously always copied — the dispatch self-refs made the sole-owner case unobservable).

Cost: executor/async continuations on shared futures already paid the +1/−1 (the old conditional `IncRef`); inline continuations gain one +1/−1 pair; the dispatch itself drops two atomic RMWs per core. Net fewer atomics for combinator and executor usage.

### Pre-existing shared/coroutine bugs found by the new tests

- **Shared readiness check**: `SharedFutureBase::Ready()` and the coroutine `await_ready` sites tested `!Empty()`, but the callback word of a shared core also holds the attached callback list — a second coroutine awaiting the same `SharedFuture` treated the first one's callback as a ready result and read an unset value. New `BaseCore::Ready()` (`kResult` acquire-load) used everywhere.
- **Coroutine executor propagation**: `PromiseType::Impl` moved the shared caller's executor; since `IntrusivePtr` move-assign swaps, every awaiting coroutine after the first inherited the wrong executor (observable via `co_await kYield` and continuation scheduling). Now copies.
- **`MakeSharedContractOn` never compiled**: declared `SharedContract` return type while constructing a `SharedFutureOn`.

### Tests

- `WhenAll.NoneRetireMovesFinishedSharedCores` now asserts **zero copies for all inputs** (was: triggering input pays one).
- New: `SharedFuture.ThenUnwrapping` (FromShared+Async grant), `SharedFuture.Subscribe` (attached + immediate grant paths), `SharedFuture.DroppedCallbackReleasesCore` (executor `Drop` grant release), `SharedFutureStress.ConcurrentSoleReaderMove`, `SharedFuture.TwoCoroutinesAwaitOneShared`, `SharedFuture.TwoCoroutinesInheritCallerExecutor` — each bite-verified against the unfixed code.

All green: C++20+CORO, C++17, `YACLIB_FAULT=THREAD`, `YACLIB_FAULT=FIBER`.