### PR TITLE
Mark Future/Promise/Task/InstrusivePtr by [[clang::trivial_abi]]

### DIFF
--- a/include/yaclib/async/future.hpp
+++ b/include/yaclib/async/future.hpp
@@ -3,6 +3,7 @@
 #include <yaclib/algo/detail/core.hpp>
 #include <yaclib/algo/detail/unique_core.hpp>
 #include <yaclib/async/wait.hpp>
+#include <yaclib/config.hpp>
 #include <yaclib/exe/executor.hpp>
 #include <yaclib/fwd.hpp>
 #include <yaclib/util/helper.hpp>
@@ -17,7 +18,7 @@ namespace yaclib {
  * Use the \ref Promise to fulfill the \ref Future.
  */
 template <typename V, typename T>
-class FutureBase {
+class YACLIB_TRIVIAL_ABI FutureBase {
   using CoreType = detail::CoreType;
 
  public:
@@ -210,7 +211,7 @@ extern template class FutureBase<void, DefaultTrait>;
  * Use the \ref Promise to fulfill the \ref Future.
  */
 template <typename V, typename T>
-class Future final : public FutureBase<V, T> {
+class YACLIB_TRIVIAL_ABI Future final : public FutureBase<V, T> {
   using CoreType = detail::CoreType;
   using Base = FutureBase<V, T>;
 
@@ -244,7 +245,7 @@ extern template class Future<>;
  * Use the \ref Promise to fulfill the \ref Future.
  */
 template <typename V, typename T>
-class FutureOn final : public FutureBase<V, T> {
+class YACLIB_TRIVIAL_ABI FutureOn final : public FutureBase<V, T> {
   using CoreType = detail::CoreType;
   using Base = FutureBase<V, T>;
 

--- a/include/yaclib/async/promise.hpp
+++ b/include/yaclib/async/promise.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <yaclib/algo/detail/unique_core.hpp>
+#include <yaclib/config.hpp>
 #include <yaclib/fwd.hpp>
 #include <yaclib/util/type_traits.hpp>
 
 namespace yaclib {
 
 template <typename V, typename T>
-class Promise final {
+class YACLIB_TRIVIAL_ABI Promise final {
   static_assert(Check<V>(), "V should be valid");
   static_assert(!std::is_same_v<V, typename T::Error>,
                 "V cannot be the same as the trait Error type, because callback dispatch would be ambiguous");

--- a/include/yaclib/lazy/task.hpp
+++ b/include/yaclib/lazy/task.hpp
@@ -3,6 +3,7 @@
 #include <yaclib/algo/detail/promise_core.hpp>
 #include <yaclib/algo/detail/result_core.hpp>
 #include <yaclib/async/future.hpp>
+#include <yaclib/config.hpp>
 #include <yaclib/exe/executor.hpp>
 #include <yaclib/exe/inline.hpp>
 #include <yaclib/fwd.hpp>
@@ -22,7 +23,7 @@ void Start(BaseCore* head) noexcept;
  * TODO(MBkkt) add description
  */
 template <typename V, typename T>
-class Task final {
+class YACLIB_TRIVIAL_ABI Task final {
   using CoreType = detail::CoreType;
 
  public:

--- a/include/yaclib/util/intrusive_ptr.hpp
+++ b/include/yaclib/util/intrusive_ptr.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <yaclib/config.hpp>
 #include <yaclib/util/ref.hpp>
 
 #include <type_traits>
@@ -14,7 +15,7 @@ struct NoRefTag final {};
  * https://www.boost.org/doc/libs/1_77_0/libs/smart_ptr/doc/html/smart_ptr.html#intrusive_ptr
  */
 template <typename T>
-class IntrusivePtr final {
+class YACLIB_TRIVIAL_ABI IntrusivePtr final {
   static_assert(std::is_base_of_v<IRef, T>, "T must be derived class of IRef");
 
  public:

--- a/src/config.hpp.in
+++ b/src/config.hpp.in
@@ -153,3 +153,12 @@
 #else
 #  define YACLIB_NO_UNIQUE_ADDRESS
 #endif
+
+#if YACLIB_HAS_ATTRIBUTE(clang::trivial_abi)
+// attribute available for clang 7 and gcc's trunk since
+// https://github.com/gcc-mirror/gcc/commit/1e89650aff94c20007f74949018f5d5150ea9ba7
+// for purpuse of portability gcc uses the same [[clang::trivial_abi]] attribute name
+#  define YACLIB_TRIVIAL_ABI [[clang::trivial_abi]]
+#else
+#  define YACLIB_TRIVIAL_ABI
+#endif


### PR DESCRIPTION
### Purpose

#248

### Related Information

- [ ] Design document: ...
- [x] Bench PR: 

I ran the following [benchmark](https://gist.github.com/Shpana/143a0c2a7aad031cae40a7c1055592ee). 
In the benchmark, the vector is filled with a large number of `Futures`/`Promises`/etc; then `shrink_to_fit` and `reserve` are repeated many times to force the vector to reallocate a buffer.

The results are presented in the table

| Type              | IntrusivePtrs |        Tasks |      Futures |     Promises |    Contracts |
|:------------------|--------------:|-------------:|-------------:|-------------:|-------------:|
| baseline          |       37089ms |      43720ms |      46707ms |      42157ms |      90228ms |
|                   |       37075ms |      43797ms |      46749ms |      42244ms |      89861ms |
|                   |       36915ms |      44378ms |      47247ms |      42175ms |      89653ms |
|                   |       36930ms |      43638ms |      46558ms |      42173ms |      90420ms |
|                   |       38055ms |      45715ms |      49415ms |      44220ms |      93900ms |
| baseline (avg)    |   **37212ms** |  **44249ms** |  **47335ms** |  **42593ms** |  **90812ms** |
|                   |               |              |              |              |              |
| trivial_abi       |       37105ms |      43970ms |      46348ms |      42991ms |      89400ms |
|                   |       37119ms |      43804ms |      46500ms |      42005ms |      90960ms |
|                   |       37437ms |      43838ms |      46272ms |      42261ms |      90138ms |
|                   |       37164ms |      43775ms |      46552ms |      42026ms |      89541ms |
|                   |       37145ms |      43829ms |      46154ms |      41949ms |      88813ms |
| trivial_abi (avg) |   **37194ms** |  **43843ms** |  **46365ms** |  **42246ms** |  **89770ms** |
| diff (avg)        |        -0.04% |        -0.9% |        -2.0% |        -0.8% |        -1.1% |

According [to](https://libcxx.llvm.org/DesignDocs/UniquePtrTrivialAbi.html), performance should increase by about 1%.

I don't exactly know why the benchmark for `IntrusivePtr` doesn't show sufficient performance difference, but attribute applies correctly 1) All conditions match https://clang.llvm.org/docs/AttributeReference.html#trivial-abi; 2) `static_assert(__is_trivially_relocatable(Future<int>), "")` doesn't fail; 3) [Check assembly](https://gist.github.com/Shpana/2363ebf90cd4267ce9bb021cadec911e)

### Testing

- [X] This change is a trivial rework or code cleanup without any test coverage.
- [ ] This change is already covered by existing tests.
- [ ] This PR adds tests that were used to verify all changes.
- [ ] There are tests in an external testing repository: ...
